### PR TITLE
include registered operator ref in agency data

### DIFF
--- a/src/functions/db-migrator/migrations/1710240961-gtfs_registered_operator_ref.ts
+++ b/src/functions/db-migrator/migrations/1710240961-gtfs_registered_operator_ref.ts
@@ -1,0 +1,10 @@
+import { Database } from "@bods-integrated-data/shared";
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+    await db.schema.alterTable("agency").addColumn("registered_operator_ref", "text").execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+    await db.schema.alterTable("agency").dropColumn("registered_operator_ref").execute();
+}

--- a/src/functions/txc-processor/data/database.ts
+++ b/src/functions/txc-processor/data/database.ts
@@ -17,6 +17,7 @@ export const insertAgencies = async (dbClient: Kysely<Database>, operators: Oper
                     name: operator.OperatorShortName,
                     noc: operator.NationalOperatorCode,
                     url: "",
+                    registeredOperatorRef: operator["@_id"],
                 },
             )
             .onConflict((oc) => oc.column("noc").doUpdateSet({ name: operator.OperatorShortName }))

--- a/src/shared/database.ts
+++ b/src/shared/database.ts
@@ -141,6 +141,7 @@ export interface GtfsAgencyTable {
     url: string;
     phone: string | null;
     noc: string;
+    registeredOperatorRef: string;
 }
 
 export type Agency = Selectable<GtfsAgencyTable>;

--- a/src/shared/schema/txc.schema.ts
+++ b/src/shared/schema/txc.schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const operatorSchema = z.object({
     NationalOperatorCode: z.string(),
     OperatorShortName: z.string(),
+    "@_id": z.string(),
 });
 
 export type Operator = z.infer<typeof operatorSchema>;


### PR DESCRIPTION
Route table mapping requires a link to a registered operator ref, so this change is to make the ref available as a property in the agency data.