### PR TITLE
Insert chunked shape data to avoid postgres parameter exhaustion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ operations/variable-scripts/variable.json
 
 # SOPS
 secrets.json
+
+# Local test data
+/data

--- a/src/functions/txc-processor/data/database.ts
+++ b/src/functions/txc-processor/data/database.ts
@@ -6,6 +6,7 @@ import {
     NewRoute,
     NewShape,
     NewStop,
+    chunkArray,
     getRouteTypeFromServiceMode,
     notEmpty,
 } from "@bods-integrated-data/shared";
@@ -202,7 +203,8 @@ export const insertShapes = async (
     });
 
     if (shapes.length > 0) {
-        await dbClient.insertInto("shape_new").values(shapes).returningAll().executeTakeFirst();
+        const insertChunks = chunkArray(shapes, 3000);
+        await Promise.all(insertChunks.map((chunk) => dbClient.insertInto("shape_new").values(chunk).execute()));
     }
 
     return updatedVehicleJourneyMappings;


### PR DESCRIPTION
Postgres runs out of parameters bindings when attempting to insert large arrays of data (>3000 parameters). Since shape data is large in nature, it is necessary to insert the data in chunks.