### PR TITLE
add GTFS bucket functional URL and read permission

### DIFF
--- a/terraform/modules/gtfs-downloader/main.tf
+++ b/terraform/modules/gtfs-downloader/main.tf
@@ -13,6 +13,11 @@ resource "aws_s3_bucket" "integrated_data_gtfs_bucket" {
   bucket = "gtfs-${var.environment}"
 }
 
+resource "aws_lambda_function_url" "gtfs_download_url" {
+  function_name      = module.integrated_data_gtfs_downloader_function.function_name
+  authorization_type = "NONE"
+}
+
 module "integrated_data_gtfs_downloader_function" {
   source = "../shared/lambda-function"
 
@@ -27,4 +32,16 @@ module "integrated_data_gtfs_downloader_function" {
   env_vars = {
     BUCKET_NAME = aws_s3_bucket.integrated_data_gtfs_bucket.bucket
   }
+
+  permissions = [
+    {
+      Action = [
+        "s3:GetObject"
+      ],
+      Effect = "Allow",
+      Resource = [
+        "${aws_s3_bucket.integrated_data_gtfs_bucket.arn}/gtfs.zip"
+      ]
+    },
+  ]
 }


### PR DESCRIPTION
The following missing configurations have been added:
- A functional URL to trigger the lambda via a public HTTP endpoint
- The policy to read the specific s3 resource