### PR TITLE
chore: add check to zip functions action

### DIFF
--- a/.github/workflows/zip_function.yaml
+++ b/.github/workflows/zip_function.yaml
@@ -42,8 +42,11 @@ jobs:
       - name: Build changed functions
         run: |
           cd ./src/functions/${{ inputs.function_dir }}
-          pnpm i
-          pnpm run build:ci
+          if [[ -f package.json ]]
+          then
+            pnpm i
+            pnpm run build:ci
+          fi
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Issue: 
When PR is created the pipeline checks the src directory to see if any changes have been made to function code. If changes have been made then it builds and zip function code. The build step will fail for nested directories as there is no build script.
(e.g. `src/functions/my-function` will work but `src/functions/another-folder/my-function` will fail).

Fix:
Update the "build changes functions" step to check if a package.json exists in the directory, if so then we build the function as expected.