### PR TITLE
BODS-4520: Add serviceStartDatetime and serviceEndDatetime to subscriber functions

### DIFF
--- a/src/functions/avl-subscriber/index.test.ts
+++ b/src/functions/avl-subscriber/index.test.ts
@@ -68,6 +68,7 @@ describe("avl-subscriber", () => {
                 shortDescription: "shortDescription",
                 status: "ACTIVE",
                 url: "https://mock-data-producer.com",
+                serviceStartDatetime: "2024-03-11T15:20:02.093Z",
             },
         );
 
@@ -121,6 +122,7 @@ describe("avl-subscriber", () => {
                 shortDescription: "shortDescription",
                 status: "FAILED",
                 url: "https://mock-data-producer.com",
+                serviceStartDatetime: null,
             },
         );
 
@@ -161,6 +163,7 @@ describe("avl-subscriber", () => {
                 shortDescription: "shortDescription",
                 status: "FAILED",
                 url: "https://mock-data-producer.com",
+                serviceStartDatetime: null,
             },
         );
 
@@ -204,6 +207,7 @@ describe("avl-subscriber", () => {
                 shortDescription: "shortDescription",
                 status: "ACTIVE",
                 url: "https://mock-data-producer.com",
+                serviceStartDatetime: "2024-03-11T15:20:02.093Z",
             },
         );
 
@@ -245,6 +249,7 @@ describe("avl-subscriber", () => {
                 shortDescription: "shortDescription",
                 status: "FAILED",
                 url: "https://mock-data-producer.com",
+                serviceStartDatetime: null,
             },
         );
 
@@ -286,6 +291,7 @@ describe("avl-subscriber", () => {
                 shortDescription: "shortDescription",
                 status: "FAILED",
                 url: "https://mock-data-producer.com",
+                serviceStartDatetime: null,
             },
         );
 

--- a/src/functions/avl-subscriber/index.ts
+++ b/src/functions/avl-subscriber/index.ts
@@ -107,6 +107,7 @@ const updateDynamoWithSubscriptionInfo = async (
     subscriptionId: string,
     avlSubscribeMessage: AvlSubscribeMessage,
     status: "ACTIVE" | "FAILED",
+    currentTimestamp?: string,
 ) => {
     const subscriptionTableItems = {
         url: avlSubscribeMessage.dataProducerEndpoint,
@@ -114,6 +115,7 @@ const updateDynamoWithSubscriptionInfo = async (
         description: avlSubscribeMessage.description,
         shortDescription: avlSubscribeMessage.shortDescription,
         requestorRef: avlSubscribeMessage.requestorRef ?? null,
+        serviceStartDatetime: currentTimestamp ?? null,
     };
 
     logger.info("Updating DynamoDB with subscription information");
@@ -199,7 +201,7 @@ const sendSubscriptionRequestAndUpdateDynamo = async (
         );
     }
 
-    await updateDynamoWithSubscriptionInfo(tableName, subscriptionId, avlSubscribeMessage, "ACTIVE");
+    await updateDynamoWithSubscriptionInfo(tableName, subscriptionId, avlSubscribeMessage, "ACTIVE", currentTimestamp);
 };
 
 export const handler = async (event: APIGatewayEvent) => {

--- a/src/functions/avl-unsubscriber/index.test.ts
+++ b/src/functions/avl-unsubscriber/index.test.ts
@@ -64,6 +64,7 @@ describe("avl-unsubscriber", () => {
             shortDescription: "test-short-description",
             status: "ACTIVE",
             requestorRef: null,
+            serviceStartDatetime: "2024-01-01T15:20:02.093Z",
         });
 
         await handler(mockUnsubscribeEvent);
@@ -78,6 +79,8 @@ describe("avl-unsubscriber", () => {
             shortDescription: "test-short-description",
             status: "TERMINATED",
             url: "https://mock-data-producer.com/",
+            serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+            serviceEndDatetime: "2024-03-11T15:20:02.093Z",
         });
 
         expect(deleteParametersSpy).toHaveBeenCalledOnce();
@@ -115,6 +118,7 @@ describe("avl-unsubscriber", () => {
             shortDescription: "test-short-description",
             status: "ACTIVE",
             requestorRef: null,
+            serviceStartDatetime: "2024-01-01T15:20:02.093Z",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError(
@@ -142,6 +146,7 @@ describe("avl-unsubscriber", () => {
             shortDescription: "test-short-description",
             status: "ACTIVE",
             requestorRef: null,
+            serviceStartDatetime: "2024-01-01T15:20:02.093Z",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError(
@@ -196,6 +201,7 @@ describe("avl-unsubscriber", () => {
             shortDescription: "test-short-description",
             status: "ACTIVE",
             requestorRef: null,
+            serviceStartDatetime: "2024-01-01T15:20:02.093Z",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError(
@@ -217,6 +223,7 @@ describe("avl-unsubscriber", () => {
             shortDescription: "test-short-description",
             status: "ACTIVE",
             requestorRef: null,
+            serviceStartDatetime: "2024-01-01T15:20:02.093Z",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError("Missing auth credentials for subscription");

--- a/src/functions/avl-unsubscriber/index.ts
+++ b/src/functions/avl-unsubscriber/index.ts
@@ -174,6 +174,7 @@ const sendTerminateSubscriptionRequestAndUpdateDynamo = async (subscription: Sub
         {
             ...subscription,
             status: "TERMINATED",
+            serviceEndDatetime: currentTimestamp,
         },
     );
 };

--- a/src/functions/avl-unsubscriber/subscription.schema.ts
+++ b/src/functions/avl-unsubscriber/subscription.schema.ts
@@ -7,6 +7,8 @@ export const subscriptionSchema = z.object({
     shortDescription: z.string(),
     status: z.string(),
     requestorRef: z.string().nullish(),
+    serviceStartDatetime: z.string().optional(),
+    serviceEndDatetime: z.string().optional(),
 });
 
 export type Subscription = z.infer<typeof subscriptionSchema>;


### PR DESCRIPTION
To test:
- run a `make setup` to update the avl-subscriber and avl-unsubscriber functions locally
- run `make command-create-avl-mock-data-producer` and follow the prompts
- check in the subscriptions dynamodb table to see if a `serviceStartDatetime` exists for your newly created data producer
- run `make command-invoke-avl-unsubscriber` and follow the prompts
- check in the subscriptions dynamodb table to see if a `serviceEndDatetime` exists for your data producer