### PR TITLE
AVL Subscription Response - Optional fields

### DIFF
--- a/src/functions/avl-subscriber/index.ts
+++ b/src/functions/avl-subscriber/index.ts
@@ -179,8 +179,6 @@ const sendSubscriptionRequestAndUpdateDynamo = async (
 
     const parsedResponseBody = parseXml(subscriptionResponseBody);
 
-    logger.info(subscriptionResponseBody);
-
     if (!parsedResponseBody) {
         await updateDynamoWithSubscriptionInfo(tableName, subscriptionId, avlSubscribeMessage, "FAILED");
         throw new Error(`Error parsing subscription response from: ${avlSubscribeMessage.dataProducerEndpoint}`);

--- a/src/shared/schema/avl-subscribe.schema.ts
+++ b/src/shared/schema/avl-subscribe.schema.ts
@@ -36,12 +36,12 @@ export type SubscriptionRequest = z.infer<typeof subscriptionRequestSchema>;
 export const subscriptionResponseSchema = z.object({
     SubscriptionResponse: z.object({
         ResponseTimestamp: z.string(),
-        ResponderRef: z.string(),
+        ResponderRef: z.string().optional(),
         RequestMessageRef: z.string().optional(),
         ResponseStatus: z.object({
             ResponseTimestamp: z.string(),
-            SubscriberRef: z.string(),
-            SubscriptionRef: z.string(),
+            SubscriberRef: z.string().optional(),
+            SubscriptionRef: z.string().optional(),
             Status: z.coerce.boolean(),
         }),
         ServiceStartedTime: z.string().optional(),


### PR DESCRIPTION
I've made some more fields from the subscription response optional. The reason for this is that when testing with new feeds some data producers are not providing these fields which is causing the subscriber lambda to fail. We do not use these fields in the subscription lambda - the only field we care about is "Status" so it should not affect functionality.