### PR TITLE
Fix/subscriber zod errors

### DIFF
--- a/src/functions/avl-data-endpoint/index.test.ts
+++ b/src/functions/avl-data-endpoint/index.test.ts
@@ -44,6 +44,7 @@ describe("AVL-data-endpoint", () => {
             shortDescription: "test-short-description",
             status: "LIVE",
             requestorRef: null,
+            publisherId: "test-publisher-id",
         });
 
         const mockEvent = {
@@ -61,6 +62,7 @@ describe("AVL-data-endpoint", () => {
             shortDescription: "test-short-description",
             status: "LIVE",
             url: "https://mock-data-producer.com/",
+            publisherId: "test-publisher-id",
         };
 
         await expect(handler(mockEvent)).resolves.toEqual({ statusCode: 200 });
@@ -89,6 +91,7 @@ describe("AVL-data-endpoint", () => {
             lastAvlDataReceivedDateTime: "2024-03-11T00:00:00.000Z",
             status: "LIVE",
             requestorRef: null,
+            publisherId: "test-publisher-id",
         };
         getDynamoItemSpy.mockResolvedValue(subscription);
 
@@ -136,6 +139,7 @@ describe("AVL-data-endpoint", () => {
             lastAvlDataReceivedDateTime: "2024-03-11T15:20:02.093Z",
             status: "LIVE",
             requestorRef: null,
+            publisherId: "test-publisher-id",
         });
 
         const mockEvent = {
@@ -157,6 +161,7 @@ describe("AVL-data-endpoint", () => {
             shortDescription: "test-short-description",
             status: "LIVE",
             requestorRef: null,
+            publisherId: "test-publisher-id",
         });
 
         const mockEvent = {
@@ -174,6 +179,7 @@ describe("AVL-data-endpoint", () => {
             shortDescription: "test-short-description",
             status: "LIVE",
             url: "https://mock-data-producer.com/",
+            publisherId: "test-publisher-id",
         };
 
         await expect(handler(mockEvent)).resolves.toEqual({ statusCode: 200 });

--- a/src/functions/avl-feed-validator/index.test.ts
+++ b/src/functions/avl-feed-validator/index.test.ts
@@ -54,6 +54,7 @@ describe("avl-feed-validator", () => {
                 requestorRef: null,
                 serviceStartDatetime: "2024-01-01T15:20:02.093Z",
                 heartbeatLastReceivedDateTime: "2024-04-29T15:14:30.000Z",
+                publisherId: "test-publisher-id",
             },
             {
                 PK: "mock-subscription-id-2",
@@ -63,6 +64,7 @@ describe("avl-feed-validator", () => {
                 status: "LIVE",
                 requestorRef: null,
                 serviceStartDatetime: "2024-04-29T15:14:30.000Z",
+                publisherId: "test-publisher-id",
             },
         ]);
 
@@ -83,6 +85,7 @@ describe("avl-feed-validator", () => {
                 requestorRef: null,
                 serviceStartDatetime: "2024-01-01T15:20:02.093Z",
                 heartbeatLastReceivedDateTime: "2024-04-29T15:14:30.000Z",
+                publisherId: "test-publisher-id",
             },
         ]);
 
@@ -99,6 +102,7 @@ describe("avl-feed-validator", () => {
             shortDescription: "test-short-description",
             status: "LIVE",
             url: "https://mock-data-producer.com/",
+            publisherId: "test-publisher-id",
         });
 
         expect(axiosSpy).not.toHaveBeenCalledOnce();
@@ -114,6 +118,7 @@ describe("avl-feed-validator", () => {
                 requestorRef: null,
                 serviceStartDatetime: "2024-01-01T15:20:02.093Z",
                 heartbeatLastReceivedDateTime: "2024-04-29T15:00:00.000Z",
+                publisherId: "test-publisher-id",
             },
             {
                 PK: "mock-subscription-id-2",
@@ -123,6 +128,7 @@ describe("avl-feed-validator", () => {
                 status: "LIVE",
                 requestorRef: null,
                 serviceStartDatetime: "2024-04-29T15:15:30.000Z",
+                publisherId: "test-publisher-id",
             },
         ]);
 
@@ -145,6 +151,7 @@ describe("avl-feed-validator", () => {
             shortDescription: "test-short-description",
             subscriptionId: "mock-subscription-id-1",
             username: "test-password",
+            publisherId: "test-publisher-id",
         });
         expect(putDynamoItemSpy).toHaveBeenCalledOnce();
         expect(putDynamoItemSpy).toBeCalledWith("test-dynamo-table", "mock-subscription-id-1", "SUBSCRIPTION", {
@@ -156,6 +163,7 @@ describe("avl-feed-validator", () => {
             shortDescription: "test-short-description",
             status: "ERROR",
             url: "https://mock-data-producer.com/",
+            publisherId: "test-publisher-id",
         });
     });
     it("should throw an error if we resubscribe to a data producer and a username or password is not found for that subscription", async () => {
@@ -169,6 +177,7 @@ describe("avl-feed-validator", () => {
                 requestorRef: null,
                 serviceStartDatetime: "2024-01-01T15:20:02.093Z",
                 heartbeatLastReceivedDateTime: "2024-04-29T15:00:00.000Z",
+                publisherId: "test-publisher-id",
             },
             {
                 PK: "mock-subscription-id-2",
@@ -178,6 +187,7 @@ describe("avl-feed-validator", () => {
                 status: "LIVE",
                 requestorRef: null,
                 serviceStartDatetime: "2024-04-29T15:15:30.000Z",
+                publisherId: "test-publisher-id",
             },
         ]);
 
@@ -198,6 +208,7 @@ describe("avl-feed-validator", () => {
             shortDescription: "test-short-description",
             status: "ERROR",
             url: "https://mock-data-producer.com/",
+            publisherId: "test-publisher-id",
         });
         expect(axiosSpy).not.toHaveBeenCalledOnce();
     });
@@ -212,6 +223,7 @@ describe("avl-feed-validator", () => {
                 requestorRef: null,
                 serviceStartDatetime: "2024-01-01T15:20:02.093Z",
                 heartbeatLastReceivedDateTime: "2024-04-29T15:00:00.000Z",
+                publisherId: "test-publisher-id",
             },
             {
                 PK: "mock-subscription-id-2",
@@ -221,6 +233,7 @@ describe("avl-feed-validator", () => {
                 status: "LIVE",
                 requestorRef: null,
                 serviceStartDatetime: "2024-04-29T15:15:30.000Z",
+                publisherId: "test-publisher-id",
             },
         ]);
 
@@ -247,6 +260,7 @@ describe("avl-feed-validator", () => {
             shortDescription: "test-short-description",
             status: "ERROR",
             url: "https://mock-data-producer.com/",
+            publisherId: "test-publisher-id",
         });
         expect(axiosSpy).toHaveBeenCalledOnce();
         expect(axiosSpy).toHaveBeenCalledOnce();

--- a/src/functions/avl-feed-validator/index.ts
+++ b/src/functions/avl-feed-validator/index.ts
@@ -2,7 +2,7 @@ import { logger } from "@baselime/lambda-logger";
 import { getAvlSubscriptions } from "@bods-integrated-data/shared/avl/utils";
 import { getDate, isDateAfter } from "@bods-integrated-data/shared/dates";
 import { putDynamoItem } from "@bods-integrated-data/shared/dynamo";
-import { AvlSubscription } from "@bods-integrated-data/shared/schema/avl-subscribe.schema";
+import { AvlSubscribeMessage, AvlSubscription } from "@bods-integrated-data/shared/schema/avl-subscribe.schema";
 import { getSubscriptionUsernameAndPassword } from "@bods-integrated-data/shared/utils";
 import axios, { AxiosError } from "axios";
 
@@ -17,7 +17,7 @@ export const resubscribeToDataProducer = async (subscription: AvlSubscription, s
         );
     }
 
-    const subscriptionBody = {
+    const subscriptionBody: AvlSubscribeMessage = {
         dataProducerEndpoint: subscription.url,
         description: subscription.description,
         shortDescription: subscription.shortDescription,
@@ -25,6 +25,7 @@ export const resubscribeToDataProducer = async (subscription: AvlSubscription, s
         password: subscriptionPassword,
         requestorRef: subscription.requestorRef ?? null,
         subscriptionId: subscription.PK,
+        publisherId: subscription.publisherId,
     };
 
     await axios.post(subscribeEndpoint, subscriptionBody);

--- a/src/functions/avl-mock-data-producer-send-data/index.test.ts
+++ b/src/functions/avl-mock-data-producer-send-data/index.test.ts
@@ -47,6 +47,7 @@ describe("avl-mock-data-producer-send-data", () => {
                 status: "LIVE",
                 requestorRef: "REAL_DATA_PRODUCER",
                 serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+                publisherId: "test-publisher-id",
             },
             {
                 PK: "subscription-one",
@@ -55,6 +56,7 @@ describe("avl-mock-data-producer-send-data", () => {
                 shortDescription: "test-short-description",
                 status: "ERROR",
                 requestorRef: "BODS_MOCK_PRODUCER",
+                publisherId: "test-publisher-id",
             },
         ]);
         await handler();

--- a/src/functions/avl-mock-data-producer-send-data/test/mockData.ts
+++ b/src/functions/avl-mock-data-producer-send-data/test/mockData.ts
@@ -9,6 +9,7 @@ export const mockSubscriptionsFromDynamo: AvlSubscription[] = [
         status: "LIVE",
         requestorRef: "BODS_MOCK_PRODUCER",
         serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+        publisherId: "test-publisher-id",
     },
     {
         PK: "subscription-two",
@@ -18,6 +19,7 @@ export const mockSubscriptionsFromDynamo: AvlSubscription[] = [
         status: "LIVE",
         requestorRef: "BODS_MOCK_PRODUCER",
         serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+        publisherId: "test-publisher-id",
     },
 ];
 

--- a/src/functions/avl-mock-data-producer-send-heartbeat/index.test.ts
+++ b/src/functions/avl-mock-data-producer-send-heartbeat/index.test.ts
@@ -46,6 +46,7 @@ describe("avl-mock-data-producer-send-data", () => {
                 status: "LIVE",
                 requestorRef: "REAL_DATA_PRODUCER",
                 serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+                publisherId: "test-publisher-id",
             },
             {
                 PK: "subscription-one",
@@ -54,6 +55,7 @@ describe("avl-mock-data-producer-send-data", () => {
                 shortDescription: "test-short-description",
                 status: "ERROR",
                 requestorRef: "BODS_MOCK_PRODUCER",
+                publisherId: "test-publisher-id",
             },
         ]);
         await handler();

--- a/src/functions/avl-mock-data-producer-send-heartbeat/test/mockData.ts
+++ b/src/functions/avl-mock-data-producer-send-heartbeat/test/mockData.ts
@@ -9,6 +9,7 @@ export const mockSubscriptionsFromDynamo: AvlSubscription[] = [
         status: "LIVE",
         requestorRef: "BODS_MOCK_PRODUCER",
         serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+        publisherId: "test-publisher-id",
     },
     {
         PK: "subscription-two",
@@ -18,6 +19,7 @@ export const mockSubscriptionsFromDynamo: AvlSubscription[] = [
         status: "LIVE",
         requestorRef: "BODS_MOCK_PRODUCER",
         serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+        publisherId: "test-publisher-id",
     },
 ];
 

--- a/src/functions/avl-processor/index.test.ts
+++ b/src/functions/avl-processor/index.test.ts
@@ -75,6 +75,7 @@ describe("avl-processor", () => {
             shortDescription: "test-short-description",
             status: "LIVE",
             requestorRef: null,
+            publisherId: "test-publisher-id",
         });
 
         uuidSpy.mockReturnValue(mockItemId);
@@ -141,6 +142,7 @@ describe("avl-processor", () => {
             shortDescription: "test-short-description",
             status,
             requestorRef: null,
+            publisherId: "test-publisher-id",
         });
 
         await expect(

--- a/src/functions/avl-subscriptions/index.test.ts
+++ b/src/functions/avl-subscriptions/index.test.ts
@@ -171,6 +171,7 @@ describe("avl-subscriptions", () => {
         it("maps AVL table data to API response data with null values for missing properties", () => {
             const subscription: AvlSubscription = {
                 PK: "mock-PK",
+                publisherId: "publisher-one",
                 url: "mock-url",
                 description: "mock-description",
                 shortDescription: "mock-shortDescription",
@@ -179,8 +180,8 @@ describe("avl-subscriptions", () => {
 
             const expectedApiResponse: ApiAvlSubscription = {
                 id: "mock-PK",
-                publisherId: null,
                 status: "LIVE",
+                publisherId: "publisher-one",
                 lastAvlDataReceivedDateTime: null,
                 heartbeatLastReceivedDateTime: null,
                 serviceStartDatetime: null,

--- a/src/functions/avl-unsubscriber/index.test.ts
+++ b/src/functions/avl-unsubscriber/index.test.ts
@@ -69,6 +69,7 @@ describe("avl-unsubscriber", () => {
             status: "LIVE",
             requestorRef: null,
             serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+            publisherId: "test-publisher-id",
         });
 
         await handler(mockUnsubscribeEvent);
@@ -89,6 +90,7 @@ describe("avl-unsubscriber", () => {
             url: "https://mock-data-producer.com/",
             serviceStartDatetime: "2024-01-01T15:20:02.093Z",
             serviceEndDatetime: "2024-03-11T15:20:02.093Z",
+            publisherId: "test-publisher-id",
         });
 
         expect(deleteParametersSpy).toHaveBeenCalledOnce();
@@ -130,6 +132,7 @@ describe("avl-unsubscriber", () => {
             status: "LIVE",
             requestorRef: null,
             serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+            publisherId: "test-publisher-id",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError("Request failed with status code 500");
@@ -155,6 +158,7 @@ describe("avl-unsubscriber", () => {
             status: "LIVE",
             requestorRef: null,
             serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+            publisherId: "test-publisher-id",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError(
@@ -182,6 +186,7 @@ describe("avl-unsubscriber", () => {
             status: "LIVE",
             requestorRef: null,
             serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+            publisherId: "test-publisher-id",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError(
@@ -209,6 +214,7 @@ describe("avl-unsubscriber", () => {
             status: "LIVE",
             requestorRef: null,
             serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+            publisherId: "test-publisher-id",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError(
@@ -231,6 +237,7 @@ describe("avl-unsubscriber", () => {
             status: "LIVE",
             requestorRef: null,
             serviceStartDatetime: "2024-01-01T15:20:02.093Z",
+            publisherId: "test-publisher-id",
         });
 
         await expect(handler(mockUnsubscribeEvent)).rejects.toThrowError("Missing auth credentials for subscription");

--- a/src/shared/schema/avl-subscribe.schema.ts
+++ b/src/shared/schema/avl-subscribe.schema.ts
@@ -66,7 +66,7 @@ export const avlSubscriptionSchema = z.object({
     heartbeatLastReceivedDateTime: z.string().nullish(),
     serviceStartDatetime: z.string().nullish(),
     serviceEndDatetime: z.string().nullish(),
-    publisherId: z.string().nullish(),
+    publisherId: z.string(),
     lastAvlDataReceivedDateTime: z.string().nullish(),
 });
 


### PR DESCRIPTION
- Made publisherId a required field for AVL Subscriptions
- Updated feed validator to use the AvlSubscribeMessage type and include publisherId in request to subscribe endpoint
- Updated AVL tests since publisherId is now required