### PR TITLE
fix: allow cancellations

### DIFF
--- a/src/functions/avl-data-endpoint/index.test.ts
+++ b/src/functions/avl-data-endpoint/index.test.ts
@@ -16,6 +16,7 @@ import {
     testSiriWithNoVehicleActivity,
     testSiriWithSelfClosingVehicleActivity,
     testSiriWithSingleVehicleActivity,
+    testVehicleActivityAndCancellationsSiri,
 } from "./testSiriVm";
 
 describe("AVL-data-endpoint", () => {
@@ -336,7 +337,15 @@ describe("AVL-data-endpoint", () => {
         expect(dynamo.putDynamoItem).not.toHaveBeenCalledOnce();
     });
 
-    it("should return a 200 but not add data to S3 if cancellations data is received", async () => {
+    it("should return a 200 and add data to S3 if vehicle activity and cancellations received", async () => {
+        mockEvent.body = testVehicleActivityAndCancellationsSiri;
+        await expect(handler(mockEvent, mockContext, mockCallback)).resolves.toEqual({ statusCode: 200, body: "" });
+
+        expect(s3.putS3Object).toHaveBeenCalledOnce();
+        expect(dynamo.putDynamoItem).toHaveBeenCalledOnce();
+    });
+
+    it("should return a 200 but not add data to S3 if only cancellations data is received", async () => {
         mockEvent.body = testCancellationsSiri;
         await expect(handler(mockEvent, mockContext, mockCallback)).resolves.toEqual({ statusCode: 200, body: "" });
 

--- a/src/functions/avl-data-endpoint/index.ts
+++ b/src/functions/avl-data-endpoint/index.ts
@@ -133,11 +133,6 @@ export const handler: APIGatewayProxyHandler & ALBHandler = async (
             return createNotFoundErrorResponse("Subscription is not live");
         }
 
-        if (siri?.ServiceDelivery?.VehicleMonitoringDelivery?.VehicleActivityCancellation) {
-            logger.warn("Received cancellation data from data producer, data will be ignored...");
-            return createSuccessResponse();
-        }
-
         if (
             siri?.ServiceDelivery?.VehicleMonitoringDelivery &&
             (!siri?.ServiceDelivery?.VehicleMonitoringDelivery?.VehicleActivity ||

--- a/src/functions/avl-data-endpoint/testSiriVm.ts
+++ b/src/functions/avl-data-endpoint/testSiriVm.ts
@@ -147,6 +147,67 @@ export const testCancellationsSiri = `<?xml version="1.0" encoding="UTF-8" stand
 </ServiceDelivery>
 </Siri>`;
 
+export const testVehicleActivityAndCancellationsSiri = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://www.siri.org.uk/siri http://www.siri.org.uk/schema/2.0/siri.xsd">
+<ServiceDelivery>
+<ResponseTimestamp>2024-08-08T09:55:06+01:00</ResponseTimestamp>
+<Status>true</Status>
+<VehicleMonitoringDelivery version="2.0">
+<ResponseTimestamp>2024-08-08T09:55:06+01:00</ResponseTimestamp>
+<SubscriberRef>CAVL_Test</SubscriberRef>
+<SubscriptionRef>10609</SubscriptionRef>
+<Status>true</Status>
+<ValidUntil>2024-08-08T09:55:06+01:00</ValidUntil>
+<ShortestPossibleCycle>PT30S</ShortestPossibleCycle>
+<VehicleActivity>
+<RecordedAtTime>2018-08-17T15:13:20</RecordedAtTime>
+<ValidUntilTime>2018-08-17T16:13:29</ValidUntilTime>
+<MonitoredVehicleJourney>
+<LineRef>ATB:Line:60</LineRef>
+<DirectionRef>2</DirectionRef>
+<OperatorRef>placeholder</OperatorRef>
+<FramedVehicleJourneyRef>
+<DataFrameRef>2018-08-17</DataFrameRef>
+<DatedVehicleJourneyRef>ATB:ServiceJourney:00600027</DatedVehicleJourneyRef>
+</FramedVehicleJourneyRef>
+<VehicleRef>200141</VehicleRef>
+<Bearing>0</Bearing>
+<VehicleLocation>
+<Longitude>10.40261</Longitude>
+<Latitude>63.43613</Latitude>
+</VehicleLocation>
+<BlockRef>blockRef</BlockRef>
+<OriginRef>originRef</OriginRef>
+<DestinationRef>destinationRef</DestinationRef>
+<PublishedLineName>1</PublishedLineName>
+</MonitoredVehicleJourney>
+</VehicleActivity>
+<VehicleActivityCancellation>
+<RecordedAtTime>2024-08-08T09:55:00+01:00</RecordedAtTime>
+<ItemRef>CAVL_TEST:VEHICLESTATUSRT:2598:15329</ItemRef>
+<VehicleMonitoringRef>TCVW-E159</VehicleMonitoringRef>
+<VehicleJourneyRef>
+<DataFrameRef>2024-08-08</DataFrameRef>
+<DatedVehicleJourneyRef>31</DatedVehicleJourneyRef>
+</VehicleJourneyRef>
+<LineRef>17</LineRef>
+<DirectionRef>OUTBOUND</DirectionRef>
+</VehicleActivityCancellation>
+<VehicleActivityCancellation>
+<RecordedAtTime>2024-08-08T09:55:00+01:00</RecordedAtTime>
+<ItemRef>CAVL_TEST:VEHICLESTATUSRT:2590:14024</ItemRef>
+<VehicleMonitoringRef>TCVW-E151</VehicleMonitoringRef>
+<VehicleJourneyRef>
+<DataFrameRef>2024-08-08</DataFrameRef>
+<DatedVehicleJourneyRef>27</DatedVehicleJourneyRef>
+</VehicleJourneyRef>
+<LineRef>13</LineRef>
+<DirectionRef>OUTBOUND</DirectionRef>
+</VehicleActivityCancellation>
+</VehicleMonitoringDelivery>
+</ServiceDelivery>
+</Siri>`;
+
 export const testSiriWithNoVehicleActivity = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Siri xmlns="http://www.siri.org.uk/siri"
     xmlns:ns2="http://www.ifopt.org.uk/acsb"

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -350,16 +350,18 @@ module "integrated_data_timetables_sfn" {
 module "integrated_data_gtfs_api" {
   source = "../modules/gtfs-api"
 
-  environment                       = local.env
-  gtfs_downloader_lambda_name       = module.integrated_data_gtfs_downloader.gtfs_downloader_lambda_name
-  gtfs_downloader_invoke_arn        = module.integrated_data_gtfs_downloader.gtfs_downloader_invoke_arn
-  gtfs_region_retriever_invoke_arn  = module.integrated_data_gtfs_downloader.gtfs_region_retriever_invoke_arn
-  gtfs_region_retriever_lambda_name = module.integrated_data_gtfs_downloader.gtfs_region_retriever_lambda_name
-  gtfs_rt_downloader_lambda_name    = module.integrated_data_gtfs_rt_pipeline.gtfs_rt_downloader_lambda_name
-  gtfs_rt_downloader_invoke_arn     = module.integrated_data_gtfs_rt_pipeline.gtfs_rt_downloader_invoke_arn
-  acm_certificate_arn               = module.integrated_data_acm.acm_certificate_arn
-  hosted_zone_id                    = module.integrated_data_route53.public_hosted_zone_id
-  domain                            = module.integrated_data_route53.public_hosted_zone_name
+  environment                                   = local.env
+  gtfs_downloader_lambda_name                   = module.integrated_data_gtfs_downloader.gtfs_downloader_lambda_name
+  gtfs_downloader_invoke_arn                    = module.integrated_data_gtfs_downloader.gtfs_downloader_invoke_arn
+  gtfs_region_retriever_invoke_arn              = module.integrated_data_gtfs_downloader.gtfs_region_retriever_invoke_arn
+  gtfs_region_retriever_lambda_name             = module.integrated_data_gtfs_downloader.gtfs_region_retriever_lambda_name
+  gtfs_rt_downloader_lambda_name                = module.integrated_data_gtfs_rt_pipeline.gtfs_rt_downloader_lambda_name
+  gtfs_rt_downloader_invoke_arn                 = module.integrated_data_gtfs_rt_pipeline.gtfs_rt_downloader_invoke_arn
+  gtfs_rt_service_alerts_downloader_lambda_name = module.integrated_data_gtfs_rt_pipeline.gtfs_rt_service_alerts_downloader_lambda_name
+  gtfs_rt_service_alerts_downloader_invoke_arn  = module.integrated_data_gtfs_rt_pipeline.gtfs_rt_service_alerts_downloader_invoke_arn
+  acm_certificate_arn                           = module.integrated_data_acm.acm_certificate_arn
+  hosted_zone_id                                = module.integrated_data_route53.public_hosted_zone_id
+  domain                                        = module.integrated_data_route53.public_hosted_zone_name
 }
 
 # VPN


### PR DESCRIPTION
SIRI-VM messages can contain a mixture of Vehicle Activities and cancellations so we need to allow that data through, since we're now checking for messages that have no vehicle activity data we shouldn't need this check anymore anyway