### PR TITLE
BODS-6689 decimal precision improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ TNDS_TXC_UNZIPPED_BUCKET_NAME="integrated-data-tnds-txc-local"
 TNDS_FTP_ARN=""
 AVL_UNPROCESSED_SIRI_BUCKET_NAME="integrated-data-avl-raw-siri-vm-local"
 AVL_SUBSCRIPTION_TABLE_NAME="integrated-data-avl-subscription-table-local"
+AVL_VALIDATION_ERROR_TABLE_NAME="integrated-data-avl-validation-error-table-local"
 AVL_SIRI_VM_DOWNLOADER_INPUT="{}"
 AVL_GENERATED_SIRI_VM_BUCKET_NAME="integrated-data-avl-generated-siri-vm-local"
 GTFS_ZIPPED_BUCKET_NAME="integrated-data-gtfs-local"
@@ -207,7 +208,7 @@ run-local-avl-data-endpoint:
 	STAGE=local SUBSCRIPTION_ID=${SUBSCRIPTION_ID} FILE="${FILE}" BUCKET_NAME=${AVL_UNPROCESSED_SIRI_BUCKET_NAME} TABLE_NAME=${AVL_SUBSCRIPTION_TABLE_NAME} npx tsx -e "import {handler} from './src/functions/avl-data-endpoint'; handler({body: '$(shell cat ${FILE} | sed -e 's/\"/\\"/g')', pathParameters: { subscriptionId:'${SUBSCRIPTION_ID}'}}).catch(e => console.error(e))"
 
 run-local-avl-processor:
-	STAGE=local FILE="${FILE}" npx tsx -e "import {handler} from './src/functions/avl-processor'; handler({Records:[{body:'{\"Records\":[{\"s3\":{\"bucket\":{\"name\":\"${AVL_UNPROCESSED_SIRI_BUCKET_NAME}\"},\"object\":{\"key\":\"${FILE}\"}}}]}'}]}).catch(e => console.error(e))"
+	STAGE=local AVL_SUBSCRIPTION_TABLE_NAME=${AVL_SUBSCRIPTION_TABLE_NAME} AVL_VALIDATION_ERROR_TABLE_NAME=${AVL_VALIDATION_ERROR_TABLE_NAME} FILE="${FILE}" npx tsx -e "import {handler} from './src/functions/avl-processor'; handler({Records:[{body:'{\"Records\":[{\"s3\":{\"bucket\":{\"name\":\"${AVL_UNPROCESSED_SIRI_BUCKET_NAME}\"},\"object\":{\"key\":\"${FILE}\"}}}]}'}]}).catch(e => console.error(e))"
 
 run-local-avl-retriever:
 	STAGE=local TARGET_BUCKET_NAME=${AVL_UNPROCESSED_SIRI_BUCKET_NAME} npx tsx -e "import {handler} from './src/functions/avl-retriever'; handler().catch(e => console.error(e))"

--- a/src/functions/avl-processor/index.test.ts
+++ b/src/functions/avl-processor/index.test.ts
@@ -233,7 +233,7 @@ describe("avl-processor", () => {
 
         expect(valuesMock).not.toHaveBeenCalled();
 
-        expect(putMetricDataSpy).toHaveBeenCalledTimes(6);
+        expect(putMetricDataSpy).toHaveBeenCalledTimes(3);
         expect(putMetricDataSpy).toHaveBeenNthCalledWith(
             1,
             expectedPutMetricDataCallForFilteredArrayParseError.namespace,
@@ -246,21 +246,6 @@ describe("avl-processor", () => {
         );
         expect(putMetricDataSpy).toHaveBeenNthCalledWith(
             3,
-            expectedPutMetricDataCallForFilteredArrayParseError.namespace,
-            expectedPutMetricDataCallForFilteredArrayParseError.metricData,
-        );
-        expect(putMetricDataSpy).toHaveBeenNthCalledWith(
-            4,
-            expectedPutMetricDataCallForFilteredArrayParseError.namespace,
-            expectedPutMetricDataCallForFilteredArrayParseError.metricData,
-        );
-        expect(putMetricDataSpy).toHaveBeenNthCalledWith(
-            5,
-            expectedPutMetricDataCallForFilteredArrayParseError.namespace,
-            expectedPutMetricDataCallForFilteredArrayParseError.metricData,
-        );
-        expect(putMetricDataSpy).toHaveBeenNthCalledWith(
-            6,
             expectedPutMetricDataCallForFilteredArrayParseError.namespace,
             expectedPutMetricDataCallForFilteredArrayParseError.metricData,
         );

--- a/src/functions/avl-processor/index.ts
+++ b/src/functions/avl-processor/index.ts
@@ -5,7 +5,7 @@ import { getDate } from "@bods-integrated-data/shared/dates";
 import { putDynamoItems } from "@bods-integrated-data/shared/dynamo";
 import { logger, withLambdaRequestTracker } from "@bods-integrated-data/shared/logger";
 import { getS3Object } from "@bods-integrated-data/shared/s3";
-import { siriSchema, siriSchemaTransformed } from "@bods-integrated-data/shared/schema";
+import { siriSchemaTransformed } from "@bods-integrated-data/shared/schema";
 import { AvlValidationError } from "@bods-integrated-data/shared/schema/avl-validation-error.schema";
 import { S3Event, S3EventRecord, SQSHandler } from "aws-lambda";
 import { XMLParser } from "fast-xml-parser";
@@ -22,8 +22,7 @@ const parseXml = (xml: string, errors: AvlValidationError[]) => {
         isArray: (tagName) => arrayProperties.includes(tagName),
     });
 
-    const parsedXml = parser.parse(xml) as Record<string, unknown>;
-    const partiallyParsedSiri = siriSchema().deepPartial().safeParse(parsedXml).data;
+    const parsedXml = parser.parse(xml);
     const parsedJson = siriSchemaTransformed(errors).safeParse(parsedXml);
 
     if (!parsedJson.success) {
@@ -46,7 +45,7 @@ const parseXml = (xml: string, errors: AvlValidationError[]) => {
     }
 
     return {
-        responseTimestamp: partiallyParsedSiri?.Siri?.ServiceDelivery?.ResponseTimestamp,
+        responseTimestamp: parsedXml?.Siri?.ServiceDelivery?.ResponseTimestamp,
         avls: parsedJson.success ? parsedJson.data : [],
     };
 };

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,3 +1,6 @@
+// Max decimal precision in JavaScript before scientific notation kicks in
+export const MAX_DECIMAL_PRECISION = 6;
+
 export const GTFS_FILE_SUFFIX = "_gtfs";
 
 export const regionCodes = ["E", "EA", "EM", "L", "NE", "NW", "S", "SE", "SW", "W", "WM", "Y", "ALL"] as const;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -132,3 +132,5 @@ export const isPrivateAddress = (url: string) => {
 
     return privateIpRegex.test(url);
 };
+
+export const roundToDecimalPlaces = (number: number, precision: number) => +number.toFixed(precision);


### PR DESCRIPTION
- fix issue where latitude/longitude/bearing with very low values (e.g. 0.000008) were being converted to scientific notation by JavaScript. The fix involves rounding the values to 6 decimal places which is enough precision for these fields.