### PR TITLE
update schema for TicketMachine to match existing schema elsewhere

### DIFF
--- a/src/shared/schema/txc.schema.ts
+++ b/src/shared/schema/txc.schema.ts
@@ -234,8 +234,10 @@ export const vehicleJourneySchema = z.object({
                 .optional(),
             TicketMachine: z
                 .object({
-                    JourneyCode: z.string().optional(),
+                    TicketMachineServiceCode: z.coerce.string().nullish(),
+                    JourneyCode: z.coerce.string().nullish(),
                 })
+                .or(txcEmptyProperty)
                 .optional(),
             VehicleType: vehicleTypeSchema.optional(),
         })


### PR DESCRIPTION
The txc property `TicketMachine` is rarely defined as empty (`<TicketMachine />`) in some files, which fails zod validation as it is processed as an empty string. We have already defined `TicketMachine` in another place that allows this behaviour, so this change is to update the schema to match.