### PR TITLE
fix boolean schema mapping

### DIFF
--- a/src/shared/schema/siri-sx/siriSxTypes.zod.ts
+++ b/src/shared/schema/siri-sx/siriSxTypes.zod.ts
@@ -26,7 +26,10 @@ import {
     VehicleMode,
 } from "./enums";
 
-export const booleanStringSchema = z.string().transform((value) => value === "true");
+export const booleanStringSchema = z
+    .literal("true")
+    .or(z.literal("false"))
+    .transform((value) => value === "true");
 
 export const iso8601DurationSchema = z.string().regex(/^PT([0-9]+\.)?[0-9]+[HMS]$/);
 


### PR DESCRIPTION
Currently the custom zod boolean schema allows any values, but it should only accept "true" and "false". This fixes the issue.