### PR TITLE
feat: Revert "add custom noc mapping for noc BDRB"

### DIFF
--- a/src/shared/gtfs-rt/utils.ts
+++ b/src/shared/gtfs-rt/utils.ts
@@ -215,10 +215,6 @@ export const getRouteKey = (avl: NewAvl) => {
             getOperatorRef: () => "NCTR",
             getLineRef: (lineRef) => lineRef.split("NT")[1],
         },
-        "753BDR": {
-            getOperatorRef: () => "BDRB",
-            getLineRef: (lineRef) => lineRef,
-        },
     };
 
     return operatorNocMap[operatorRef]


### PR DESCRIPTION
Reverts Department-for-Transport-Disruptions/bods-integrated-data#466

The custom mapping is no longer needed as the incoming data has been fixed