### PR TITLE
fix: use stop area codes for lookup instead of atco code

### DIFF
--- a/src/functions/txc-processor/data/database.ts
+++ b/src/functions/txc-processor/data/database.ts
@@ -135,11 +135,15 @@ export const getNaptanStops = (dbClient: KyselyDb, atcoCodes: string[], useStopL
         .execute();
 };
 
-export const getNaptanStopAreas = (dbClient: KyselyDb, atcoCodes: string[]) => {
+export const getNaptanStopAreas = (dbClient: KyselyDb, stopAreaCodes: (string | null)[]) => {
     return dbClient
         .selectFrom("naptan_stop_area_new")
         .selectAll("naptan_stop_area_new")
-        .where("naptan_stop_area_new.stop_area_code", "in", atcoCodes)
+        .where(
+            "naptan_stop_area_new.stop_area_code",
+            "in",
+            stopAreaCodes.filter((code) => code !== null),
+        )
         .execute();
 };
 

--- a/src/functions/txc-processor/data/stops.test.ts
+++ b/src/functions/txc-processor/data/stops.test.ts
@@ -230,13 +230,14 @@ describe("stops", () => {
             };
 
             const naptanStop: Partial<NaptanStopWithRegionCode> = {
-                atco_code: "111",
+                atco_code: "123",
                 naptan_code: "4",
                 common_name: "naptan_name",
                 stop_type: "BCS",
                 latitude: "5",
                 longitude: "6",
                 region_code: "Y",
+                stop_area_code: "111",
             };
 
             const expected: NewStop[] = [
@@ -286,13 +287,14 @@ describe("stops", () => {
             };
 
             const naptanStop: Partial<NaptanStopWithRegionCode> = {
-                atco_code: "111",
+                atco_code: "123",
                 naptan_code: "4",
                 common_name: "naptan_name",
                 stop_type: "BCE",
                 latitude: "5",
                 longitude: "6",
                 region_code: "Y",
+                stop_area_code: "111",
             };
 
             const expected: NewStop[] = [

--- a/src/functions/txc-processor/data/stops.ts
+++ b/src/functions/txc-processor/data/stops.ts
@@ -24,7 +24,7 @@ export const mapStop = (
     naptanStop?: NaptanStopWithRegionCode,
 ): NewStop[] => {
     const stop: NewStop = {
-        id: id.toUpperCase(),
+        id,
         wheelchair_boarding: WheelchairAccessibility.NoAccessibilityInformation,
         parent_station: null,
         stop_name: name.trim(),
@@ -58,8 +58,14 @@ export const mapStop = (
 
         if (naptanStop.stop_type && naptanPlatformStopTypeCodes.includes(naptanStop.stop_type)) {
             stop.platform_code = naptanStop.stop_type;
+        }
 
-            const stopArea = naptanStopAreaMap[naptanStop.atco_code];
+        if (
+            naptanStop.stop_type &&
+            naptanStop.stop_area_code &&
+            naptanPlatformStopTypeCodes.includes(naptanStop.stop_type)
+        ) {
+            const stopArea = naptanStopAreaMap[naptanStop.stop_area_code];
 
             if (stopArea) {
                 stop.parent_station = stopArea.stop_area_code;
@@ -67,8 +73,12 @@ export const mapStop = (
             }
         }
 
-        if (naptanStop.stop_type && naptanStationStopTypeCodes.includes(naptanStop.stop_type)) {
-            const stopArea = naptanStopAreaMap[naptanStop.atco_code];
+        if (
+            naptanStop.stop_type &&
+            naptanStop.stop_area_code &&
+            naptanStationStopTypeCodes.includes(naptanStop.stop_type)
+        ) {
+            const stopArea = naptanStopAreaMap[naptanStop.stop_area_code];
 
             if (stopArea) {
                 stop.parent_station = stopArea.stop_area_code;
@@ -118,7 +128,7 @@ export const createStopAreaStop = (
     }
 
     return {
-        id: stopArea.stop_area_code.toUpperCase(),
+        id: stopArea.stop_area_code,
         wheelchair_boarding: WheelchairAccessibility.NoAccessibilityInformation,
         parent_station: null,
         stop_name: stopArea.name.trim(),
@@ -174,9 +184,10 @@ export const getCoordinates = (location?: StopPointLocation) => {
 };
 
 export const processStopPoints = async (dbClient: KyselyDb, stops: TxcStopPoint[], useStopLocality: boolean) => {
-    const atcoCodes = stops.map((stop) => stop.AtcoCode);
+    const atcoCodes = stops.map((stop) => stop.AtcoCode.toUpperCase());
     const naptanStops = await getNaptanStops(dbClient, atcoCodes, useStopLocality);
-    const naptanStopAreas = await getNaptanStopAreas(dbClient, atcoCodes);
+    const naptanStopAreaCodes = naptanStops.map((s) => s.stop_area_code);
+    const naptanStopAreas = await getNaptanStopAreas(dbClient, naptanStopAreaCodes);
     const naptanStopAreaMap: Record<string, NaptanStopArea> = {};
 
     for (const naptanStopArea of naptanStopAreas) {
@@ -208,7 +219,8 @@ export const processAnnotatedStopPointRefs = async (
 ) => {
     const atcoCodes = stops.map((stop) => stop.StopPointRef);
     const naptanStops = await getNaptanStops(dbClient, atcoCodes, useStopLocality);
-    const naptanStopAreas = await getNaptanStopAreas(dbClient, atcoCodes);
+    const naptanStopAreaCodes = naptanStops.map((s) => s.stop_area_code);
+    const naptanStopAreas = await getNaptanStopAreas(dbClient, naptanStopAreaCodes);
     const naptanStopAreaMap: Record<string, NaptanStopArea> = {};
 
     for (const naptanStopArea of naptanStopAreas) {

--- a/src/shared/schema/naptan.schema.ts
+++ b/src/shared/schema/naptan.schema.ts
@@ -132,7 +132,7 @@ export const naptanSchemaTransformed = naptanSchema.transform((item) => {
     if (item.NaPTAN.StopPoints.StopPoint.length > 0) {
         const transformedStopPoints = item.NaPTAN.StopPoints.StopPoint.map((stop) => {
             const newStop: NewNaptanStop = {
-                atco_code: stop.AtcoCode,
+                atco_code: stop.AtcoCode.toUpperCase(),
                 naptan_code: stop.NaptanCode ?? null,
                 plate_code: stop.PlateCode ?? null,
                 cleardown_code: stop.CleardownCode ?? null,
@@ -171,7 +171,8 @@ export const naptanSchemaTransformed = naptanSchema.transform((item) => {
                 revision_number: null,
                 modification: null,
                 status: null,
-                stop_area_code: stop.StopAreas?.StopAreaRef?.length === 1 ? stop.StopAreas.StopAreaRef[0] : null,
+                stop_area_code:
+                    stop.StopAreas?.StopAreaRef?.length === 1 ? stop.StopAreas.StopAreaRef[0].toUpperCase() : null,
             };
 
             return newStop;
@@ -183,7 +184,7 @@ export const naptanSchemaTransformed = naptanSchema.transform((item) => {
     if (item.NaPTAN.StopAreas && item.NaPTAN.StopAreas.StopArea.length > 0) {
         const transformedStopAreas = item.NaPTAN.StopAreas.StopArea.map((stopArea) => {
             const newStopArea: NewNaptanStopArea = {
-                stop_area_code: stopArea.StopAreaCode,
+                stop_area_code: stopArea.StopAreaCode.toUpperCase(),
                 name: stopArea.Name,
                 administrative_area_code: stopArea.AdministrativeAreaRef,
                 stop_area_type: stopArea.StopAreaType,


### PR DESCRIPTION
- stop area lookup was incorrectly using a TXC stop's atco code instead of the NaPTAN stop's stop area code
- move `toUpperCase()` transforms to before DB inserts