### PR TITLE
feat: add global catch to gtfs step function

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -77,6 +77,7 @@ module "integrated_data_aurora_db_dev" {
   private_hosted_zone_id   = module.integrated_data_route53.private_hosted_zone_id
   private_hosted_zone_name = module.integrated_data_route53.private_hosted_zone_name
   instance_class           = "db.r6g.large"
+  db_engine_version        = "16.6"
 }
 
 module "integrated_data_db_monitoring" {

--- a/terraform/modules/database/aurora-db/main.tf
+++ b/terraform/modules/database/aurora-db/main.tf
@@ -129,7 +129,7 @@ resource "aws_iam_role" "rds_enhanced_monitoring_role" {
 
 resource "aws_rds_cluster" "integrated_data_rds_cluster" {
   engine                      = "aurora-postgresql"
-  engine_version              = "16.1"
+  engine_version              = var.db_engine_version
   engine_mode                 = "provisioned"
   master_username             = "postgres"
   manage_master_user_password = true
@@ -156,7 +156,7 @@ resource "aws_rds_cluster_role_association" "integrated_data_rds_cluster_s3_expo
 resource "aws_rds_cluster_instance" "integrated_data_postgres_db_instance" {
   cluster_identifier                    = aws_rds_cluster.integrated_data_rds_cluster.id
   engine                                = "aurora-postgresql"
-  engine_version                        = "16.1"
+  engine_version                        = var.db_engine_version
   instance_class                        = var.instance_class
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
@@ -169,7 +169,7 @@ resource "aws_rds_cluster_instance" "integrated_data_postgres_db_read_replica_in
   count                                 = var.multi_az ? 1 : 0
   cluster_identifier                    = aws_rds_cluster.integrated_data_rds_cluster.id
   engine                                = "aurora-postgresql"
-  engine_version                        = "16.1"
+  engine_version                        = var.db_engine_version
   instance_class                        = var.instance_class
   performance_insights_enabled          = true
   performance_insights_retention_period = 7

--- a/terraform/modules/database/aurora-db/variables.tf
+++ b/terraform/modules/database/aurora-db/variables.tf
@@ -37,3 +37,8 @@ variable "private_hosted_zone_name" {
   type        = string
   description = "Name of the private hosted zone"
 }
+
+variable "db_engine_version" {
+  type        = string
+  description = "DB engine version"
+}

--- a/terraform/modules/timetables-sfn/timetables-state-machine.asl.json
+++ b/terraform/modules/timetables-sfn/timetables-state-machine.asl.json
@@ -1417,12 +1417,12 @@
                     "ErrorEquals": [
                         "States.ALL"
                     ],
-                    "Next": "Generate Trip Map"
+                    "Next": "Generate Trip Map Fallback"
                 }
             ],
             "End": true
         },
-        "Generate Trip Map": {
+        "Generate Trip Map Fallback": {
             "Type": "Task",
             "Resource": "arn:aws:states:::lambda:invoke",
             "OutputPath": "$.Payload",

--- a/terraform/modules/timetables-sfn/timetables-state-machine.asl.json
+++ b/terraform/modules/timetables-sfn/timetables-state-machine.asl.json
@@ -1,39 +1,19 @@
 {
-    "Comment": "Import reference data and generate GTFS timetables",
-    "StartAt": "DB Cleardown",
+    "Comment": "Global Error Handler",
+    "StartAt": "Error Handler",
     "States": {
-        "DB Cleardown": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "Parameters": {
-                "FunctionName": "${db_cleardown_function_arn}:$LATEST"
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "Retrieve and Process Reference Data"
-        },
-        "Retrieve and Process Reference Data": {
+        "Error Handler": {
             "Type": "Parallel",
             "Branches": [
                 {
-                    "StartAt": "Retrieve NOC Data",
+                    "Comment": "Import reference data and generate GTFS timetables",
+                    "StartAt": "DB Cleardown",
                     "States": {
-                        "Retrieve NOC Data": {
+                        "DB Cleardown": {
                             "Type": "Task",
                             "Resource": "arn:aws:states:::lambda:invoke",
                             "Parameters": {
-                                "FunctionName": "${noc_retriever_function_arn}:$LATEST"
+                                "FunctionName": "${db_cleardown_function_arn}:$LATEST"
                             },
                             "Retry": [
                                 {
@@ -48,940 +28,1399 @@
                                     "BackoffRate": 2
                                 }
                             ],
-                            "Next": "Process NOC Data"
+                            "Next": "Retrieve and Process Reference Data"
                         },
-                        "Process NOC Data": {
+                        "Retrieve and Process Reference Data": {
+                            "Type": "Parallel",
+                            "Branches": [
+                                {
+                                    "StartAt": "Retrieve NOC Data",
+                                    "States": {
+                                        "Retrieve NOC Data": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "Parameters": {
+                                                "FunctionName": "${noc_retriever_function_arn}:$LATEST"
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "Process NOC Data"
+                                        },
+                                        "Process NOC Data": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${noc_processor_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "Records": [
+                                                        {
+                                                            "s3": {
+                                                                "object": {
+                                                                    "key": "noc.xml"
+                                                                },
+                                                                "bucket": {
+                                                                    "name": "${noc_bucket_name}"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "End": true
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Retrieve NPTG Data",
+                                    "States": {
+                                        "Retrieve NPTG Data": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "Parameters": {
+                                                "FunctionName": "${nptg_retriever_function_arn}:$LATEST"
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "Process NPTG Data"
+                                        },
+                                        "Process NPTG Data": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "Parameters": {
+                                                "FunctionName": "${nptg_uploader_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "Records": [
+                                                        {
+                                                            "s3": {
+                                                                "object": {
+                                                                    "key": "NPTG.xml"
+                                                                },
+                                                                "bucket": {
+                                                                    "name": "${nptg_bucket_name}"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "Retrieve NaPTAN Data"
+                                        },
+                                        "Retrieve NaPTAN Data": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "Parameters": {
+                                                "FunctionName": "${naptan_retriever_function_arn}:$LATEST"
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "Process NaPTAN Data"
+                                        },
+                                        "Process NaPTAN Data": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "Parameters": {
+                                                "FunctionName": "${naptan_uploader_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "Records": [
+                                                        {
+                                                            "s3": {
+                                                                "bucket": {
+                                                                    "name": "${naptan_bucket_name}"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "End": true,
+                                            "ResultPath": null
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Retrieve Bank Holidays Data",
+                                    "States": {
+                                        "Retrieve Bank Holidays Data": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "Parameters": {
+                                                "FunctionName": "${bank_holidays_retriever_function_arn}:$LATEST"
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "End": true
+                                        }
+                                    }
+                                }
+                            ],
+                            "Next": "Retrieve BODS TXC Data"
+                        },
+                        "Retrieve BODS TXC Data": {
                             "Type": "Task",
                             "Resource": "arn:aws:states:::lambda:invoke",
+                            "Parameters": {
+                                "FunctionName": "${bods_txc_retriever_function_arn}:$LATEST"
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
                             "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${noc_processor_function_arn}:$LATEST",
-                                "Payload": {
-                                    "Records": [
-                                        {
-                                            "s3": {
-                                                "object": {
-                                                    "key": "noc.xml"
-                                                },
-                                                "bucket": {
-                                                    "name": "${noc_bucket_name}"
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "End": true
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Retrieve NPTG Data",
-                    "States": {
-                        "Retrieve NPTG Data": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "Parameters": {
-                                "FunctionName": "${nptg_retriever_function_arn}:$LATEST"
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "Process NPTG Data"
+                            "Next": "Get Zipped BODS TXC Keys"
                         },
-                        "Process NPTG Data": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "Parameters": {
-                                "FunctionName": "${nptg_uploader_function_arn}:$LATEST",
-                                "Payload": {
-                                    "Records": [
-                                        {
-                                            "s3": {
-                                                "object": {
-                                                    "key": "NPTG.xml"
-                                                },
-                                                "bucket": {
-                                                    "name": "${nptg_bucket_name}"
-                                                }
+                        "Get Zipped BODS TXC Keys": {
+                            "Type": "Map",
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "DISTRIBUTED",
+                                    "ExecutionType": "STANDARD"
+                                },
+                                "StartAt": "Unzip BODS TXC Data",
+                                "States": {
+                                    "Unzip BODS TXC Data": {
+                                        "Type": "Task",
+                                        "Resource": "arn:aws:states:::lambda:invoke",
+                                        "Parameters": {
+                                            "FunctionName": "${unzipper_function_arn}:$LATEST",
+                                            "Payload": {
+                                                "Records": [
+                                                    {
+                                                        "s3": {
+                                                            "bucket": {
+                                                                "name": "${bods_txc_zipped_bucket_name}"
+                                                            },
+                                                            "object": {
+                                                                "key.$": "$.Key"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
                                             }
-                                        }
-                                    ]
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "Retrieve NaPTAN Data"
-                        },
-                        "Retrieve NaPTAN Data": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "Parameters": {
-                                "FunctionName": "${naptan_retriever_function_arn}:$LATEST"
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "Process NaPTAN Data"
-                        },
-                        "Process NaPTAN Data": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "Parameters": {
-                                "FunctionName": "${naptan_uploader_function_arn}:$LATEST",
-                                "Payload": {
-                                    "Records": [
-                                        {
-                                            "s3": {
-                                                "bucket": {
-                                                    "name": "${naptan_bucket_name}"
-                                                }
+                                        },
+                                        "End": true,
+                                        "Retry": [
+                                            {
+                                                "ErrorEquals": [
+                                                    "Lambda.ServiceException",
+                                                    "Lambda.AWSLambdaException",
+                                                    "Lambda.SdkClientException",
+                                                    "Lambda.TooManyRequestsException"
+                                                ],
+                                                "BackoffRate": 2,
+                                                "IntervalSeconds": 1,
+                                                "MaxAttempts": 3
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 }
                             },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
+                            "ItemReader": {
+                                "Resource": "arn:aws:states:::s3:listObjectsV2",
+                                "Parameters": {
+                                    "Bucket.$": "$.bodsTxcZippedBucketName",
+                                    "Prefix.$": "$.prefix"
                                 }
-                            ],
-                            "End": true,
+                            },
+                            "ResultPath": null,
+                            "Next": "Get BODS TXC Object Keys"
+                        },
+                        "Get BODS TXC Object Keys": {
+                            "Type": "Map",
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "DISTRIBUTED",
+                                    "ExecutionType": "STANDARD"
+                                },
+                                "StartAt": "Process BODS TXC",
+                                "States": {
+                                    "Process BODS TXC": {
+                                        "Type": "Task",
+                                        "Resource": "arn:aws:states:::lambda:invoke",
+                                        "Parameters": {
+                                            "FunctionName": "${txc_processor_function_arn}:$LATEST",
+                                            "Payload": {
+                                                "Records": [
+                                                    {
+                                                        "s3": {
+                                                            "bucket": {
+                                                                "name": "${bods_txc_bucket_name}"
+                                                            },
+                                                            "object": {
+                                                                "key.$": "$.Key"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "ItemReader": {
+                                "Resource": "arn:aws:states:::s3:listObjectsV2",
+                                "Parameters": {
+                                    "Bucket": "${bods_txc_bucket_name}",
+                                    "Prefix.$": "$.prefix"
+                                }
+                            },
+                            "MaxConcurrency": 50,
+                            "ToleratedFailureCount": 10,
+                            "Next": "Retrieve TNDS TXC Data",
                             "ResultPath": null
+                        },
+                        "Retrieve TNDS TXC Data": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "Parameters": {
+                                "FunctionName": "${tnds_txc_retriever_function_arn}:$LATEST"
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "Get Zipped TNDS TXC Keys",
+                            "OutputPath": "$.Payload"
+                        },
+                        "Get Zipped TNDS TXC Keys": {
+                            "Type": "Map",
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "DISTRIBUTED",
+                                    "ExecutionType": "STANDARD"
+                                },
+                                "StartAt": "Unzip TNDS TXC Data",
+                                "States": {
+                                    "Unzip TNDS TXC Data": {
+                                        "Type": "Task",
+                                        "Resource": "arn:aws:states:::lambda:invoke",
+                                        "Parameters": {
+                                            "FunctionName": "${unzipper_function_arn}:$LATEST",
+                                            "Payload": {
+                                                "Records": [
+                                                    {
+                                                        "s3": {
+                                                            "bucket": {
+                                                                "name": "${tnds_txc_zipped_bucket_name}"
+                                                            },
+                                                            "object": {
+                                                                "key.$": "$.Key"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "Retry": [
+                                            {
+                                                "ErrorEquals": [
+                                                    "Lambda.ServiceException",
+                                                    "Lambda.AWSLambdaException",
+                                                    "Lambda.SdkClientException",
+                                                    "Lambda.TooManyRequestsException"
+                                                ],
+                                                "IntervalSeconds": 1,
+                                                "MaxAttempts": 3,
+                                                "BackoffRate": 2
+                                            }
+                                        ],
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "ItemReader": {
+                                "Resource": "arn:aws:states:::s3:listObjectsV2",
+                                "Parameters": {
+                                    "Bucket.$": "$.tndsTxcZippedBucketName",
+                                    "Prefix.$": "$.prefix"
+                                }
+                            },
+                            "ResultPath": null,
+                            "Next": "Get TNDS TXC Object Keys"
+                        },
+                        "Get TNDS TXC Object Keys": {
+                            "Type": "Map",
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "DISTRIBUTED",
+                                    "ExecutionType": "STANDARD"
+                                },
+                                "StartAt": "Process TNDS TXC",
+                                "States": {
+                                    "Process TNDS TXC": {
+                                        "Type": "Task",
+                                        "Resource": "arn:aws:states:::lambda:invoke",
+                                        "Parameters": {
+                                            "FunctionName": "${txc_processor_function_arn}:$LATEST",
+                                            "Payload": {
+                                                "Records": [
+                                                    {
+                                                        "s3": {
+                                                            "bucket": {
+                                                                "name": "${tnds_txc_bucket_name}"
+                                                            },
+                                                            "object": {
+                                                                "key.$": "$.Key"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "ItemReader": {
+                                "Resource": "arn:aws:states:::s3:listObjectsV2",
+                                "Parameters": {
+                                    "Bucket": "${tnds_txc_bucket_name}",
+                                    "Prefix.$": "$.prefix"
+                                }
+                            },
+                            "MaxConcurrency": 50,
+                            "ToleratedFailureCount": 10,
+                            "ResultPath": null,
+                            "Next": "Retrieve TfL Data"
+                        },
+                        "Retrieve TfL Data": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "Parameters": {
+                                "FunctionName": "${tfl_timetable_retriever_function_arn}:$LATEST"
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "Get Zipped TfL Keys",
+                            "OutputPath": "$.Payload"
+                        },
+                        "Get Zipped TfL Keys": {
+                            "Type": "Map",
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "DISTRIBUTED",
+                                    "ExecutionType": "STANDARD"
+                                },
+                                "StartAt": "Unzip TfL Data",
+                                "States": {
+                                    "Unzip TfL Data": {
+                                        "Type": "Task",
+                                        "Resource": "arn:aws:states:::lambda:invoke",
+                                        "Parameters": {
+                                            "FunctionName": "${tfl_timetable_unzipper_function_arn}:$LATEST",
+                                            "Payload": {
+                                                "Records": [
+                                                    {
+                                                        "s3": {
+                                                            "bucket": {
+                                                                "name": "${tfl_timetable_zipped_bucket_name}"
+                                                            },
+                                                            "object": {
+                                                                "key.$": "$.Key"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "Retry": [
+                                            {
+                                                "ErrorEquals": [
+                                                    "Lambda.ServiceException",
+                                                    "Lambda.AWSLambdaException",
+                                                    "Lambda.SdkClientException",
+                                                    "Lambda.TooManyRequestsException"
+                                                ],
+                                                "IntervalSeconds": 1,
+                                                "MaxAttempts": 3,
+                                                "BackoffRate": 2
+                                            }
+                                        ],
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "ItemReader": {
+                                "Resource": "arn:aws:states:::s3:listObjectsV2",
+                                "Parameters": {
+                                    "Bucket.$": "$.tflTimetableZippedBucketName",
+                                    "Prefix.$": "$.prefix"
+                                }
+                            },
+                            "ResultPath": null,
+                            "Next": "Get TfL Object Keys"
+                        },
+                        "Get TfL Object Keys": {
+                            "Type": "Map",
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "DISTRIBUTED",
+                                    "ExecutionType": "STANDARD"
+                                },
+                                "StartAt": "Process TfL Data",
+                                "States": {
+                                    "Process TfL Data": {
+                                        "Type": "Task",
+                                        "Resource": "arn:aws:states:::lambda:invoke",
+                                        "Parameters": {
+                                            "FunctionName": "${tfl_timetable_processor_function_arn}:$LATEST",
+                                            "Payload": {
+                                                "Records": [
+                                                    {
+                                                        "s3": {
+                                                            "bucket": {
+                                                                "name": "${tfl_timetable_bucket_name}"
+                                                            },
+                                                            "object": {
+                                                                "key.$": "$.Key"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "ItemReader": {
+                                "Resource": "arn:aws:states:::s3:listObjectsV2",
+                                "Parameters": {
+                                    "Bucket": "${tfl_timetable_bucket_name}",
+                                    "Prefix.$": "$.prefix"
+                                }
+                            },
+                            "MaxConcurrency": 50,
+                            "ToleratedFailureCount": 10,
+                            "ResultPath": null,
+                            "Next": "Run Table Renamer"
+                        },
+                        "Run Table Renamer": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "Parameters": {
+                                "FunctionName": "${table_renamer_function_arn}:$LATEST"
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "Run Trip Table Creator"
+                        },
+                        "Run Trip Table Creator": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "OutputPath": "$.Payload",
+                            "Parameters": {
+                                "FunctionName": "${gtfs_timetables_trip_table_creator_function_arn}:$LATEST"
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "National GTFS"
+                        },
+                        "National GTFS": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "OutputPath": "$.Payload",
+                            "Parameters": {
+                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                "Payload": {}
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "England GTFS"
+                        },
+                        "England GTFS": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "OutputPath": "$.Payload",
+                            "Parameters": {
+                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                "Payload": {
+                                    "regionCode": "E"
+                                }
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "London GTFS"
+                        },
+                        "London GTFS": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "OutputPath": "$.Payload",
+                            "Parameters": {
+                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                "Payload": {
+                                    "regionCode": "L"
+                                }
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "South East GTFS"
+                        },
+                        "South East GTFS": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "OutputPath": "$.Payload",
+                            "Parameters": {
+                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                "Payload": {
+                                    "regionCode": "SE"
+                                }
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "South West GTFS"
+                        },
+                        "South West GTFS": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "OutputPath": "$.Payload",
+                            "Parameters": {
+                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                "Payload": {
+                                    "regionCode": "SW"
+                                }
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "Generate Remaining GTFS"
+                        },
+                        "Generate Remaining GTFS": {
+                            "Type": "Parallel",
+                            "Next": "Generate Trip Map",
+                            "Branches": [
+                                {
+                                    "StartAt": "Wales GTFS",
+                                    "States": {
+                                        "Wales GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "W"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "Scotland GTFS"
+                                        },
+                                        "Scotland GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "S"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "North West GTFS"
+                                        },
+                                        "North West GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "NW"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "West Midlands GTFS"
+                                        },
+                                        "West Midlands GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "WM"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "End": true
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Yorkshire GTFS",
+                                    "States": {
+                                        "Yorkshire GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "Y"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "East Anglia GTFS"
+                                        },
+                                        "East Anglia GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "EA"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "East Midlands GTFS"
+                                        },
+                                        "East Midlands GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "EM"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "Next": "North East GTFS"
+                                        },
+                                        "North East GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "NE"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ],
+                                            "End": true
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "Generate Trip Map": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "OutputPath": "$.Payload",
+                            "Parameters": {
+                                "FunctionName": "${gtfs_timetables_trip_mapper_function_arn}:$LATEST",
+                                "Payload": {}
+                            },
+                            "Retry": [
+                                {
+                                    "ErrorEquals": [
+                                        "Lambda.ServiceException",
+                                        "Lambda.AWSLambdaException",
+                                        "Lambda.SdkClientException",
+                                        "Lambda.TooManyRequestsException"
+                                    ],
+                                    "IntervalSeconds": 1,
+                                    "MaxAttempts": 3,
+                                    "BackoffRate": 2
+                                }
+                            ],
+                            "Next": "Zip GTFS"
+                        },
+                        "Zip GTFS": {
+                            "Type": "Parallel",
+                            "End": true,
+                            "Branches": [
+                                {
+                                    "StartAt": "Zip National GTFS",
+                                    "States": {
+                                        "Zip National GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "ALL"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip England GTFS",
+                                    "States": {
+                                        "Zip England GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "E"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip London GTFS",
+                                    "States": {
+                                        "Zip London GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "L"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip South East GTFS",
+                                    "States": {
+                                        "Zip South East GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "SE"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip South West GTFS",
+                                    "States": {
+                                        "Zip South West GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "SW"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip Wales GTFS",
+                                    "States": {
+                                        "Zip Wales GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "W"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip Scotland GTFS",
+                                    "States": {
+                                        "Zip Scotland GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "S"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip North West GTFS",
+                                    "States": {
+                                        "Zip North West GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "NW"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip West Midlands GTFS",
+                                    "States": {
+                                        "Zip West Midlands GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "WM"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip Yorkshire GTFS",
+                                    "States": {
+                                        "Zip Yorkshire GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "Y"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip East Anglia GTFS",
+                                    "States": {
+                                        "Zip East Anglia GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "EA"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip East Midlands GTFS",
+                                    "States": {
+                                        "Zip East Midlands GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "EM"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "StartAt": "Zip North East GTFS",
+                                    "States": {
+                                        "Zip North East GTFS": {
+                                            "Type": "Task",
+                                            "Resource": "arn:aws:states:::lambda:invoke",
+                                            "OutputPath": "$.Payload",
+                                            "End": true,
+                                            "Parameters": {
+                                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
+                                                "Payload": {
+                                                    "regionCode": "NE"
+                                                }
+                                            },
+                                            "Retry": [
+                                                {
+                                                    "ErrorEquals": [
+                                                        "Lambda.ServiceException",
+                                                        "Lambda.AWSLambdaException",
+                                                        "Lambda.SdkClientException",
+                                                        "Lambda.TooManyRequestsException"
+                                                    ],
+                                                    "IntervalSeconds": 1,
+                                                    "MaxAttempts": 3,
+                                                    "BackoffRate": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
-                },
-                {
-                    "StartAt": "Retrieve Bank Holidays Data",
-                    "States": {
-                        "Retrieve Bank Holidays Data": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "Parameters": {
-                                "FunctionName": "${bank_holidays_retriever_function_arn}:$LATEST"
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "End": true
-                        }
-                    }
                 }
             ],
-            "Next": "Retrieve BODS TXC Data"
-        },
-        "Retrieve BODS TXC Data": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "Parameters": {
-                "FunctionName": "${bods_txc_retriever_function_arn}:$LATEST"
-            },
-            "Retry": [
+            "Catch": [
                 {
                     "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
+                        "States.ALL"
                     ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
+                    "Next": "Generate Trip Map"
                 }
             ],
-            "OutputPath": "$.Payload",
-            "Next": "Get Zipped BODS TXC Keys"
-        },
-        "Get Zipped BODS TXC Keys": {
-            "Type": "Map",
-            "ItemProcessor": {
-                "ProcessorConfig": {
-                    "Mode": "DISTRIBUTED",
-                    "ExecutionType": "STANDARD"
-                },
-                "StartAt": "Unzip BODS TXC Data",
-                "States": {
-                    "Unzip BODS TXC Data": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:states:::lambda:invoke",
-                        "Parameters": {
-                            "FunctionName": "${unzipper_function_arn}:$LATEST",
-                            "Payload": {
-                                "Records": [
-                                    {
-                                        "s3": {
-                                            "bucket": {
-                                                "name": "${bods_txc_zipped_bucket_name}"
-                                            },
-                                            "object": {
-                                                "key.$": "$.Key"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "End": true,
-                        "Retry": [
-                            {
-                                "ErrorEquals": [
-                                    "Lambda.ServiceException",
-                                    "Lambda.AWSLambdaException",
-                                    "Lambda.SdkClientException",
-                                    "Lambda.TooManyRequestsException"
-                                ],
-                                "BackoffRate": 2,
-                                "IntervalSeconds": 1,
-                                "MaxAttempts": 3
-                            }
-                        ]
-                    }
-                }
-            },
-            "ItemReader": {
-                "Resource": "arn:aws:states:::s3:listObjectsV2",
-                "Parameters": {
-                    "Bucket.$": "$.bodsTxcZippedBucketName",
-                    "Prefix.$": "$.prefix"
-                }
-            },
-            "ResultPath": null,
-            "Next": "Get BODS TXC Object Keys"
-        },
-        "Get BODS TXC Object Keys": {
-            "Type": "Map",
-            "ItemProcessor": {
-                "ProcessorConfig": {
-                    "Mode": "DISTRIBUTED",
-                    "ExecutionType": "STANDARD"
-                },
-                "StartAt": "Process BODS TXC",
-                "States": {
-                    "Process BODS TXC": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:states:::lambda:invoke",
-                        "Parameters": {
-                            "FunctionName": "${txc_processor_function_arn}:$LATEST",
-                            "Payload": {
-                                "Records": [
-                                    {
-                                        "s3": {
-                                            "bucket": {
-                                                "name": "${bods_txc_bucket_name}"
-                                            },
-                                            "object": {
-                                                "key.$": "$.Key"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "End": true
-                    }
-                }
-            },
-            "ItemReader": {
-                "Resource": "arn:aws:states:::s3:listObjectsV2",
-                "Parameters": {
-                    "Bucket": "${bods_txc_bucket_name}",
-                    "Prefix.$": "$.prefix"
-                }
-            },
-            "MaxConcurrency": 50,
-            "ToleratedFailureCount": 10,
-            "Next": "Retrieve TNDS TXC Data",
-            "ResultPath": null
-        },
-        "Retrieve TNDS TXC Data": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "Parameters": {
-                "FunctionName": "${tnds_txc_retriever_function_arn}:$LATEST"
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "Get Zipped TNDS TXC Keys",
-            "OutputPath": "$.Payload"
-        },
-        "Get Zipped TNDS TXC Keys": {
-            "Type": "Map",
-            "ItemProcessor": {
-                "ProcessorConfig": {
-                    "Mode": "DISTRIBUTED",
-                    "ExecutionType": "STANDARD"
-                },
-                "StartAt": "Unzip TNDS TXC Data",
-                "States": {
-                    "Unzip TNDS TXC Data": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:states:::lambda:invoke",
-                        "Parameters": {
-                            "FunctionName": "${unzipper_function_arn}:$LATEST",
-                            "Payload": {
-                                "Records": [
-                                    {
-                                        "s3": {
-                                            "bucket": {
-                                                "name": "${tnds_txc_zipped_bucket_name}"
-                                            },
-                                            "object": {
-                                                "key.$": "$.Key"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Retry": [
-                            {
-                                "ErrorEquals": [
-                                    "Lambda.ServiceException",
-                                    "Lambda.AWSLambdaException",
-                                    "Lambda.SdkClientException",
-                                    "Lambda.TooManyRequestsException"
-                                ],
-                                "IntervalSeconds": 1,
-                                "MaxAttempts": 3,
-                                "BackoffRate": 2
-                            }
-                        ],
-                        "End": true
-                    }
-                }
-            },
-            "ItemReader": {
-                "Resource": "arn:aws:states:::s3:listObjectsV2",
-                "Parameters": {
-                    "Bucket.$": "$.tndsTxcZippedBucketName",
-                    "Prefix.$": "$.prefix"
-                }
-            },
-            "ResultPath": null,
-            "Next": "Get TNDS TXC Object Keys"
-        },
-        "Get TNDS TXC Object Keys": {
-            "Type": "Map",
-            "ItemProcessor": {
-                "ProcessorConfig": {
-                    "Mode": "DISTRIBUTED",
-                    "ExecutionType": "STANDARD"
-                },
-                "StartAt": "Process TNDS TXC",
-                "States": {
-                    "Process TNDS TXC": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:states:::lambda:invoke",
-                        "Parameters": {
-                            "FunctionName": "${txc_processor_function_arn}:$LATEST",
-                            "Payload": {
-                                "Records": [
-                                    {
-                                        "s3": {
-                                            "bucket": {
-                                                "name": "${tnds_txc_bucket_name}"
-                                            },
-                                            "object": {
-                                                "key.$": "$.Key"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "End": true
-                    }
-                }
-            },
-            "ItemReader": {
-                "Resource": "arn:aws:states:::s3:listObjectsV2",
-                "Parameters": {
-                    "Bucket": "${tnds_txc_bucket_name}",
-                    "Prefix.$": "$.prefix"
-                }
-            },
-            "MaxConcurrency": 50,
-            "ToleratedFailureCount": 10,
-            "ResultPath": null,
-            "Next": "Retrieve TfL Data"
-        },
-        "Retrieve TfL Data": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "Parameters": {
-                "FunctionName": "${tfl_timetable_retriever_function_arn}:$LATEST"
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "Get Zipped TfL Keys",
-            "OutputPath": "$.Payload"
-        },
-        "Get Zipped TfL Keys": {
-            "Type": "Map",
-            "ItemProcessor": {
-                "ProcessorConfig": {
-                    "Mode": "DISTRIBUTED",
-                    "ExecutionType": "STANDARD"
-                },
-                "StartAt": "Unzip TfL Data",
-                "States": {
-                    "Unzip TfL Data": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:states:::lambda:invoke",
-                        "Parameters": {
-                            "FunctionName": "${tfl_timetable_unzipper_function_arn}:$LATEST",
-                            "Payload": {
-                                "Records": [
-                                    {
-                                        "s3": {
-                                            "bucket": {
-                                                "name": "${tfl_timetable_zipped_bucket_name}"
-                                            },
-                                            "object": {
-                                                "key.$": "$.Key"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Retry": [
-                            {
-                                "ErrorEquals": [
-                                    "Lambda.ServiceException",
-                                    "Lambda.AWSLambdaException",
-                                    "Lambda.SdkClientException",
-                                    "Lambda.TooManyRequestsException"
-                                ],
-                                "IntervalSeconds": 1,
-                                "MaxAttempts": 3,
-                                "BackoffRate": 2
-                            }
-                        ],
-                        "End": true
-                    }
-                }
-            },
-            "ItemReader": {
-                "Resource": "arn:aws:states:::s3:listObjectsV2",
-                "Parameters": {
-                    "Bucket.$": "${tfl_timetable_zipped_bucket_name}",
-                    "Prefix.$": "$.prefix"
-                }
-            },
-            "ResultPath": null,
-            "Next": "Get TfL Object Keys"
-        },
-        "Get TfL Object Keys": {
-            "Type": "Map",
-            "ItemProcessor": {
-                "ProcessorConfig": {
-                    "Mode": "DISTRIBUTED",
-                    "ExecutionType": "STANDARD"
-                },
-                "StartAt": "Process TfL Data",
-                "States": {
-                    "Process TfL Data": {
-                        "Type": "Task",
-                        "Resource": "arn:aws:states:::lambda:invoke",
-                        "Parameters": {
-                            "FunctionName": "${tfl_timetable_processor_function_arn}:$LATEST",
-                            "Payload": {
-                                "Records": [
-                                    {
-                                        "s3": {
-                                            "bucket": {
-                                                "name": "${tfl_timetable_bucket_name}"
-                                            },
-                                            "object": {
-                                                "key.$": "$.Key"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "End": true
-                    }
-                }
-            },
-            "ItemReader": {
-                "Resource": "arn:aws:states:::s3:listObjectsV2",
-                "Parameters": {
-                    "Bucket": "${tfl_timetable_bucket_name}",
-                    "Prefix.$": "$.prefix"
-                }
-            },
-            "MaxConcurrency": 50,
-            "ToleratedFailureCount": 10,
-            "ResultPath": null,
-            "Next": "Run Table Renamer"
-        },
-        "Run Table Renamer": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "Parameters": {
-                "FunctionName": "${table_renamer_function_arn}:$LATEST"
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "Run Trip Table Creator"
-        },
-        "Run Trip Table Creator": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "OutputPath": "$.Payload",
-            "Parameters": {
-                "FunctionName": "${gtfs_timetables_trip_table_creator_function_arn}:$LATEST"
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "National GTFS"
-        },
-        "National GTFS": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "OutputPath": "$.Payload",
-            "Parameters": {
-                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                "Payload": {}
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "England GTFS"
-        },
-        "England GTFS": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "OutputPath": "$.Payload",
-            "Parameters": {
-                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                "Payload": {
-                    "regionCode": "E"
-                }
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "London GTFS"
-        },
-        "London GTFS": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "OutputPath": "$.Payload",
-            "Parameters": {
-                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                "Payload": {
-                    "regionCode": "L"
-                }
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "South East GTFS"
-        },
-        "South East GTFS": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "OutputPath": "$.Payload",
-            "Parameters": {
-                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                "Payload": {
-                    "regionCode": "SE"
-                }
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "South West GTFS"
-        },
-        "South West GTFS": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "OutputPath": "$.Payload",
-            "Parameters": {
-                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                "Payload": {
-                    "regionCode": "SW"
-                }
-            },
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "Lambda.ServiceException",
-                        "Lambda.AWSLambdaException",
-                        "Lambda.SdkClientException",
-                        "Lambda.TooManyRequestsException"
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "Generate Remaining GTFS"
-        },
-        "Generate Remaining GTFS": {
-            "Type": "Parallel",
-            "Next": "Generate Trip Map",
-            "Branches": [
-                {
-                    "StartAt": "Wales GTFS",
-                    "States": {
-                        "Wales GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "W"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "Scotland GTFS"
-                        },
-                        "Scotland GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "S"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "North West GTFS"
-                        },
-                        "North West GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "NW"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "West Midlands GTFS"
-                        },
-                        "West Midlands GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "WM"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "End": true
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Yorkshire GTFS",
-                    "States": {
-                        "Yorkshire GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "Y"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "East Anglia GTFS"
-                        },
-                        "East Anglia GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "EA"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "East Midlands GTFS"
-                        },
-                        "East Midlands GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "EM"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "Next": "North East GTFS"
-                        },
-                        "North East GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_generator_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "NE"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ],
-                            "End": true
-                        }
-                    }
-                }
-            ]
+            "End": true
         },
         "Generate Trip Map": {
             "Type": "Task",
@@ -1004,403 +1443,10 @@
                     "BackoffRate": 2
                 }
             ],
-            "Next": "Zip GTFS"
+            "Next": "Job Failed"
         },
-        "Zip GTFS": {
-            "Type": "Parallel",
-            "End": true,
-            "Branches": [
-                {
-                    "StartAt": "Zip National GTFS",
-                    "States": {
-                        "Zip National GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "ALL"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip England GTFS",
-                    "States": {
-                        "Zip England GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "E"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip London GTFS",
-                    "States": {
-                        "Zip London GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "L"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip South East GTFS",
-                    "States": {
-                        "Zip South East GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "SE"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip South West GTFS",
-                    "States": {
-                        "Zip South West GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "SW"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip Wales GTFS",
-                    "States": {
-                        "Zip Wales GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "W"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip Scotland GTFS",
-                    "States": {
-                        "Zip Scotland GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "S"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip North West GTFS",
-                    "States": {
-                        "Zip North West GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "NW"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip West Midlands GTFS",
-                    "States": {
-                        "Zip West Midlands GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "WM"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip Yorkshire GTFS",
-                    "States": {
-                        "Zip Yorkshire GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "Y"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip East Anglia GTFS",
-                    "States": {
-                        "Zip East Anglia GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "EA"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip East Midlands GTFS",
-                    "States": {
-                        "Zip East Midlands GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "EM"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Zip North East GTFS",
-                    "States": {
-                        "Zip North East GTFS": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "OutputPath": "$.Payload",
-                            "End": true,
-                            "Parameters": {
-                                "FunctionName": "${gtfs_timetables_zipper_function_arn}:$LATEST",
-                                "Payload": {
-                                    "regionCode": "NE"
-                                }
-                            },
-                            "Retry": [
-                                {
-                                    "ErrorEquals": [
-                                        "Lambda.ServiceException",
-                                        "Lambda.AWSLambdaException",
-                                        "Lambda.SdkClientException",
-                                        "Lambda.TooManyRequestsException"
-                                    ],
-                                    "IntervalSeconds": 1,
-                                    "MaxAttempts": 3,
-                                    "BackoffRate": 2
-                                }
-                            ]
-                        }
-                    }
-                }
-            ]
+        "Job Failed": {
+            "Type": "Fail"
         }
     }
 }

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -83,6 +83,7 @@ module "integrated_data_aurora_db" {
   private_hosted_zone_name = module.integrated_data_route53.private_hosted_zone_name
   multi_az                 = true
   instance_class           = "db.r6g.xlarge"
+  db_engine_version        = "16.1"
 }
 
 module "integrated_data_db_monitoring" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -78,6 +78,7 @@ module "integrated_data_aurora_db" {
   private_hosted_zone_name = module.integrated_data_route53.private_hosted_zone_name
   multi_az                 = false
   instance_class           = "db.r6g.xlarge"
+  db_engine_version        = "16.6"
 }
 
 module "integrated_data_db_monitoring" {


### PR DESCRIPTION
To ensure the trip map generation always runs in the daily job, even when a failure occurs, a global catch is included in the step function defintion to generate the trip map