### PR TITLE
feat: updates to avl cancellations

### DIFF
--- a/src/functions/db-migrator/migrations/1748430260-avl_cancellations_unique_constraint.ts
+++ b/src/functions/db-migrator/migrations/1748430260-avl_cancellations_unique_constraint.ts
@@ -14,7 +14,7 @@ export async function up(db: Kysely<Database>): Promise<void> {
             "dated_vehicle_journey_ref",
             "line_ref",
             "direction_ref",
-            "subscription_id",
+            "vehicle_monitoring_ref",
         ])
         .execute();
 }

--- a/src/functions/db-migrator/migrations/1748430260-avl_cancellations_unique_constraint.ts
+++ b/src/functions/db-migrator/migrations/1748430260-avl_cancellations_unique_constraint.ts
@@ -17,6 +17,12 @@ export async function up(db: Kysely<Database>): Promise<void> {
             "vehicle_monitoring_ref",
         ])
         .execute();
+
+    await db.schema
+        .createIndex("idx_avl_join")
+        .on("avl")
+        .columns(["data_frame_ref", "dated_vehicle_journey_ref", "line_ref", "direction_ref", "vehicle_monitoring_ref"])
+        .execute();
 }
 
 export async function down(db: Kysely<Database>): Promise<void> {
@@ -34,4 +40,6 @@ export async function down(db: Kysely<Database>): Promise<void> {
             "direction_ref",
         ])
         .execute();
+
+    await db.schema.dropIndex("idx_avl_join").on("avl").execute();
 }

--- a/src/functions/db-migrator/migrations/1748430260-avl_cancellations_unique_constraint.ts
+++ b/src/functions/db-migrator/migrations/1748430260-avl_cancellations_unique_constraint.ts
@@ -1,0 +1,37 @@
+import { Database } from "@bods-integrated-data/shared/database";
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+    await db.schema
+        .alterTable("avl_cancellation")
+        .dropConstraint("uniq_avl_cancellation_data_frame_journey_line_direction_ref")
+        .execute();
+
+    await db.schema
+        .alterTable("avl_cancellation")
+        .addUniqueConstraint("uniq_avl_cancellation_data_frame_journey_line_direction_ref", [
+            "data_frame_ref",
+            "dated_vehicle_journey_ref",
+            "line_ref",
+            "direction_ref",
+            "subscription_id",
+        ])
+        .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+    await db.schema
+        .alterTable("avl_cancellation")
+        .dropConstraint("uniq_avl_cancellation_data_frame_journey_line_direction_ref")
+        .execute();
+
+    await db.schema
+        .alterTable("avl_cancellation")
+        .addUniqueConstraint("uniq_avl_cancellation_data_frame_journey_line_direction_ref", [
+            "data_frame_ref",
+            "dated_vehicle_journey_ref",
+            "line_ref",
+            "direction_ref",
+        ])
+        .execute();
+}

--- a/src/shared/avl/utils.ts
+++ b/src/shared/avl/utils.ts
@@ -272,7 +272,7 @@ export const getQueryForLatestAvl = (dbClient: KyselyDb, avlQueryOptions: AvlQue
                     .onRef("avl_cancellation.dated_vehicle_journey_ref", "=", "avl.dated_vehicle_journey_ref")
                     .onRef("avl_cancellation.line_ref", "=", "avl.line_ref")
                     .onRef("avl_cancellation.direction_ref", "=", "avl.direction_ref")
-                    .onRef("avl_cancellation.subscription_id", "=", "avl.subscription_id"),
+                    .onRef("avl_cancellation.vehicle_monitoring_ref", "=", "avl.vehicle_monitoring_ref"),
             )
             .where("avl_cancellation.dated_vehicle_journey_ref", "is", null);
     }

--- a/src/shared/avl/utils.ts
+++ b/src/shared/avl/utils.ts
@@ -271,7 +271,8 @@ export const getQueryForLatestAvl = (dbClient: KyselyDb, avlQueryOptions: AvlQue
                     .onRef("avl_cancellation.data_frame_ref", "=", "avl.data_frame_ref")
                     .onRef("avl_cancellation.dated_vehicle_journey_ref", "=", "avl.dated_vehicle_journey_ref")
                     .onRef("avl_cancellation.line_ref", "=", "avl.line_ref")
-                    .onRef("avl_cancellation.direction_ref", "=", "avl.direction_ref"),
+                    .onRef("avl_cancellation.direction_ref", "=", "avl.direction_ref")
+                    .onRef("avl_cancellation.subscription_id", "=", "avl.subscription_id"),
             )
             .where("avl_cancellation.dated_vehicle_journey_ref", "is", null);
     }

--- a/terraform/modules/data-pipelines/avl-pipeline/main.tf
+++ b/terraform/modules/data-pipelines/avl-pipeline/main.tf
@@ -91,7 +91,7 @@ module "integrated_data_avl_processor_function" {
     AVL_SUBSCRIPTION_TABLE_NAME     = var.avl_subscription_table_name
     AVL_VALIDATION_ERROR_TABLE_NAME = var.avl_validation_error_table_name
     GTFS_TRIP_MAPS_TABLE_NAME       = var.gtfs_trip_maps_table_name
-    ENABLE_CANCELLATIONS            = var.enable_cancellations ? "true" : "false"
+    ENABLE_CANCELLATIONS            = "true"
   }
 }
 
@@ -707,7 +707,7 @@ module "integrated_data_siri_cleardown_lambda" {
   vpc_id          = var.vpc_id
   subnet_ids      = var.private_subnet_ids
   database_sg_id  = var.db_sg_id
-  schedule        = "cron(0 0 * * ? *)"
+  schedule        = var.environment == "prod" ? "rate(1 hour)" : "cron(0 0 * * ? *)"
 
   permissions = [
     {

--- a/terraform/modules/data-pipelines/avl-pipeline/main.tf
+++ b/terraform/modules/data-pipelines/avl-pipeline/main.tf
@@ -707,7 +707,7 @@ module "integrated_data_siri_cleardown_lambda" {
   vpc_id          = var.vpc_id
   subnet_ids      = var.private_subnet_ids
   database_sg_id  = var.db_sg_id
-  schedule        = var.environment == "prod" ? "rate(1 hour)" : "cron(0 0 * * ? *)"
+  schedule        = "rate(1 hour)"
 
   permissions = [
     {


### PR DESCRIPTION
- update unique key constraint for avl_cancellations table to include subscription ID
- update join for AVL query to include subscription ID
- update siri cleardown to run every hour
- update avl processor ENABLE_CANCELLATIONS env var to always be true