### PR TITLE
chore: remove unused acm certificate

### DIFF
--- a/terraform/modules/networking/acm/main.tf
+++ b/terraform/modules/networking/acm/main.tf
@@ -9,6 +9,11 @@ terraform {
   }
 }
 
+provider "aws" {
+  alias  = "us_east"
+  region = "us-east-1"
+}
+
 resource "aws_acm_certificate" "integrated_data_acm_certificate" {
   domain_name               = var.domain_name
   subject_alternative_names = ["*.${var.domain_name}"]

--- a/terraform/modules/networking/acm/main.tf
+++ b/terraform/modules/networking/acm/main.tf
@@ -9,11 +9,6 @@ terraform {
   }
 }
 
-provider "aws" {
-  alias  = "us_east"
-  region = "us-east-1"
-}
-
 resource "aws_acm_certificate" "integrated_data_acm_certificate" {
   domain_name               = var.domain_name
   subject_alternative_names = ["*.${var.domain_name}"]
@@ -44,43 +39,4 @@ resource "aws_route53_record" "integrated_data_acm_validation_record" {
 resource "aws_acm_certificate_validation" "integrated_data_acm_validation" {
   certificate_arn         = aws_acm_certificate.integrated_data_acm_certificate.arn
   validation_record_fqdns = [for record in aws_route53_record.integrated_data_acm_validation_record : record.fqdn]
-}
-
-resource "aws_acm_certificate" "integrated_data_cloudfront_acm_certificate" {
-  domain_name               = var.domain_name
-  subject_alternative_names = ["*.${var.domain_name}"]
-  validation_method         = "DNS"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-
-  provider = aws.us_east
-}
-
-resource "aws_route53_record" "integrated_data_cloudfront_acm_validation_record" {
-  for_each = {
-    for dvo in aws_acm_certificate.integrated_data_cloudfront_acm_certificate.domain_validation_options : dvo.domain_name
-    => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
-  allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
-  type            = each.value.type
-  zone_id         = var.hosted_zone_id
-}
-
-resource "aws_acm_certificate_validation" "integrated_data_cloudfront_acm_validation" {
-  certificate_arn = aws_acm_certificate.integrated_data_cloudfront_acm_certificate.arn
-  validation_record_fqdns = [
-    for record in aws_route53_record.integrated_data_cloudfront_acm_validation_record : record.fqdn
-  ]
-
-  provider = aws.us_east
 }

--- a/terraform/modules/networking/acm/outputs.tf
+++ b/terraform/modules/networking/acm/outputs.tf
@@ -1,7 +1,3 @@
 output "acm_certificate_arn" {
   value = aws_acm_certificate.integrated_data_acm_certificate.arn
 }
-
-output "cloudfront_acm_certificate_arn" {
-  value = aws_acm_certificate.integrated_data_cloudfront_acm_certificate.arn
-}


### PR DESCRIPTION
Remove unused acm certificate (moved from cloudfront distro to private api gateway)

This PR is needed as the cert has expired in dev and is preventing terraform to apply infra changes.