### PR TITLE
chore: update terraform to reflect aurora bump to 16.11

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -77,7 +77,7 @@ module "integrated_data_aurora_db_dev" {
   private_hosted_zone_id   = module.integrated_data_route53.private_hosted_zone_id
   private_hosted_zone_name = module.integrated_data_route53.private_hosted_zone_name
   instance_class           = "db.r6g.large"
-  db_engine_version        = "16.8"
+  db_engine_version        = "16.11"
 }
 
 module "integrated_data_db_monitoring" {

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -83,7 +83,7 @@ module "integrated_data_aurora_db" {
   private_hosted_zone_name = module.integrated_data_route53.private_hosted_zone_name
   multi_az                 = true
   instance_class           = "db.r6g.xlarge"
-  db_engine_version        = "16.8"
+  db_engine_version        = "16.11"
 }
 
 module "integrated_data_db_monitoring" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -78,7 +78,7 @@ module "integrated_data_aurora_db" {
   private_hosted_zone_name = module.integrated_data_route53.private_hosted_zone_name
   multi_az                 = false
   instance_class           = "db.r6g.xlarge"
-  db_engine_version        = "16.8"
+  db_engine_version        = "16.11"
 }
 
 module "integrated_data_db_monitoring" {


### PR DESCRIPTION
Resolves issue where terraform was previously asking for 16.8 and thus trying to downgrade