### PR TITLE
chore(ci): Update all github action versions

### DIFF
--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -37,7 +37,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -107,7 +107,7 @@ jobs:
           merge-multiple: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -12,6 +12,7 @@ env:
   TERRAFORM_VERSION: 1.6.6
   HUSKY: 0
   TZ: "Europe/London"
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   lint_pr_title:

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -12,7 +12,6 @@ env:
   TERRAFORM_VERSION: 1.6.6
   HUSKY: 0
   TZ: "Europe/London"
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   lint_pr_title:
@@ -28,15 +27,15 @@ jobs:
     name: Lint code and run unit tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.x"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: 9
           run_install: false
@@ -45,7 +44,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('src/pnpm-lock.yaml') }}
@@ -100,16 +99,16 @@ jobs:
     environment: dev
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download zipped functions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./src/functions/dist
           merge-multiple: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}
@@ -122,7 +121,7 @@ jobs:
           key: dev-tflint-${{ hashFiles('terraform/.tflint.hcl') }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v5
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -150,7 +149,7 @@ jobs:
         run: terraform -chdir=dev plan -lock-timeout=5m -input=false -no-color -out .planfile
 
       - name: Post PR comment with Terraform plan
-        uses: borchero/terraform-plan-comment@v2
+        uses: borchero/terraform-plan-comment@v3
         with:
           token: ${{ github.token }}
           working-directory: ./terraform/dev

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Lint PR title
     runs-on: ubuntu-24.04
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -114,13 +114,13 @@ jobs:
           role-session-name: GitHub-OIDC-TERRAFORM
 
       - name: Cache Terraform tflint plugin
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.tflint.d/plugins
           key: dev-tflint-${{ hashFiles('terraform/.tflint.hcl') }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v5
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -128,7 +128,7 @@ jobs:
         run: terraform fmt -check -recursive
 
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v4
+        uses: terraform-linters/setup-tflint@v6
         with:
           tflint_wrapper: true
 

--- a/.github/workflows/create_draft_release.yaml
+++ b/.github/workflows/create_draft_release.yaml
@@ -57,7 +57,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/create_draft_release.yaml
+++ b/.github/workflows/create_draft_release.yaml
@@ -2,6 +2,7 @@ name: Create draft release
 
 env:
   TERRAFORM_VERSION: 1.6.6
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 on:
   workflow_dispatch:

--- a/.github/workflows/create_draft_release.yaml
+++ b/.github/workflows/create_draft_release.yaml
@@ -52,7 +52,7 @@ jobs:
           merge-multiple: true
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v5
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 

--- a/.github/workflows/create_draft_release.yaml
+++ b/.github/workflows/create_draft_release.yaml
@@ -2,7 +2,6 @@ name: Create draft release
 
 env:
   TERRAFORM_VERSION: 1.6.6
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 on:
   workflow_dispatch:
@@ -44,21 +43,21 @@ jobs:
       - zip_functions
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download zipped functions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./src/functions/dist
           merge-multiple: true
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v5
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}
@@ -71,7 +70,7 @@ jobs:
         run: terraform -chdir=terraform/prod plan -lock-timeout=5m -input=false -no-color -out .planfile
 
       - name: Create formatted Terraform plan
-        uses: borchero/terraform-plan-comment@v2
+        uses: borchero/terraform-plan-comment@v3
         with:
           token: ${{ github.token }}
           working-directory: ./terraform/prod
@@ -86,7 +85,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}${{ inputs.is_hotfix && ' (hotfix)' || '' }}

--- a/.github/workflows/deploy_code.yaml
+++ b/.github/workflows/deploy_code.yaml
@@ -81,7 +81,7 @@ jobs:
           merge-multiple: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/deploy_code.yaml
+++ b/.github/workflows/deploy_code.yaml
@@ -29,6 +29,9 @@ jobs:
     outputs:
       all_functions: ${{ steps.get_list_of_functions.outputs.all_functions }}
     steps:
+      - name: Check env var
+        run: echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=$ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION"
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/deploy_code.yaml
+++ b/.github/workflows/deploy_code.yaml
@@ -20,7 +20,6 @@ permissions:
 
 env:
   TERRAFORM_VERSION: 1.6.6
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   get_functions_and_tasks:
@@ -33,7 +32,7 @@ jobs:
         run: echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=$ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get list of functions
         id: get_list_of_functions
@@ -73,23 +72,23 @@ jobs:
       - zip_functions
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download zipped functions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./src/functions/dist
           merge-multiple: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}
           role-session-name: GitHub-OIDC-TERRAFORM
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v5
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 

--- a/.github/workflows/deploy_code.yaml
+++ b/.github/workflows/deploy_code.yaml
@@ -88,7 +88,7 @@ jobs:
           role-session-name: GitHub-OIDC-TERRAFORM
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v5
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 

--- a/.github/workflows/deploy_code.yaml
+++ b/.github/workflows/deploy_code.yaml
@@ -20,6 +20,7 @@ permissions:
 
 env:
   TERRAFORM_VERSION: 1.6.6
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   get_functions_and_tasks:

--- a/.github/workflows/get_directories_with_changes.yaml
+++ b/.github/workflows/get_directories_with_changes.yaml
@@ -16,6 +16,9 @@ on:
       changed_directories:
         value: ${{ jobs.get_directories_with_changes.outputs.changed_directories }}
 
+env:
+    ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   get_directories_with_changes:
     runs-on: ubuntu-24.04

--- a/.github/workflows/get_directories_with_changes.yaml
+++ b/.github/workflows/get_directories_with_changes.yaml
@@ -16,9 +16,6 @@ on:
       changed_directories:
         value: ${{ jobs.get_directories_with_changes.outputs.changed_directories }}
 
-env:
-    ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   get_directories_with_changes:
     runs-on: ubuntu-24.04
@@ -27,7 +24,7 @@ jobs:
       changed_directories: ${{ steps.set-output-changed-directories.outputs.changed_directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/get_directories_with_changes.yaml
+++ b/.github/workflows/get_directories_with_changes.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Get changed directories
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           path: ${{ inputs.path }}
           dir_names: true
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get changed files for shared code
         id: changed-files-shared-code
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v47
         with:
           path: ${{ inputs.shared_code_path }}
           dir_names_max_depth: 1

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -27,19 +27,18 @@ jobs:
     name: Run integration tests
     env:
       STAGE: ${{ inputs.stage }}
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     environment: ${{ inputs.stage }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.x"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: 9
           run_install: false
@@ -56,7 +55,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -40,7 +40,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -46,7 +46,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('src/pnpm-lock.yaml') }}

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -54,7 +54,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -27,6 +27,7 @@ jobs:
     name: Run integration tests
     env:
       STAGE: ${{ inputs.stage }}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     environment: ${{ inputs.stage }}
     steps:
       - name: Checkout code

--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm test
 
       - name: Upload integration test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: integration-testing/playwright-report/

--- a/.github/workflows/zip_function.yaml
+++ b/.github/workflows/zip_function.yaml
@@ -7,24 +7,21 @@ on:
         required: true
         type: string
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   zip_function:
     runs-on: ubuntu-24.04
     name: Zip function (${{ inputs.function_dir }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.x"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: 9
           run_install: false

--- a/.github/workflows/zip_function.yaml
+++ b/.github/workflows/zip_function.yaml
@@ -29,7 +29,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('src/pnpm-lock.yaml') }}

--- a/.github/workflows/zip_function.yaml
+++ b/.github/workflows/zip_function.yaml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   zip_function:
     runs-on: ubuntu-24.04

--- a/.github/workflows/zip_function.yaml
+++ b/.github/workflows/zip_function.yaml
@@ -23,7 +23,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/zip_function.yaml
+++ b/.github/workflows/zip_function.yaml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm build:ci
 
       - name: Upload function zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.function_dir }}
           path: ./src/functions/${{ inputs.function_dir }}/dist/${{ inputs.function_dir }}.zip

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -8,3 +8,8 @@ plugin "aws" {
     version = "0.47.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
+
+// remove this after lambda runtime is upgraded
+rule "aws_lambda_function_deprecated_runtime" {
+  enabled = false
+}

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -5,6 +5,6 @@ plugin "terraform" {
 
 plugin "aws" {
     enabled = true
-    version = "0.29.0"
+    version = "0.47.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/terraform/modules/data-pipelines/avl-pipeline/main.tf
+++ b/terraform/modules/data-pipelines/avl-pipeline/main.tf
@@ -344,7 +344,7 @@ resource "aws_iam_policy" "siri_vm_generator_ecs_task_policy" {
       {
         "Effect" : "Allow",
         "Action" : "sns:Publish",
-        "Resource" : "${aws_sns_topic.integrated_data_avl_sirivm_sns_topic.arn}"
+        "Resource" : aws_sns_topic.integrated_data_avl_sirivm_sns_topic.arn
       }
     ]
   })

--- a/terraform/modules/data-pipelines/avl-pipeline/variables.tf
+++ b/terraform/modules/data-pipelines/avl-pipeline/variables.tf
@@ -8,12 +8,6 @@ variable "vpc_id" {
   description = "VPC ID"
 }
 
-variable "sg_id" {
-  type     = string
-  default  = null
-  nullable = true
-}
-
 variable "private_subnet_ids" {
   type        = list(string)
   description = "List of Subnet IDs"

--- a/terraform/modules/data-pipelines/cancellations-pipeline/main.tf
+++ b/terraform/modules/data-pipelines/cancellations-pipeline/main.tf
@@ -9,8 +9,6 @@ terraform {
   }
 }
 
-data "aws_caller_identity" "current" {}
-
 module "integrated_data_cancellations_s3_sqs" {
   source = "../../shared/s3-sqs"
 

--- a/terraform/modules/networking/acm/main.tf
+++ b/terraform/modules/networking/acm/main.tf
@@ -9,11 +9,6 @@ terraform {
   }
 }
 
-provider "aws" {
-  alias  = "us_east"
-  region = "us-east-1"
-}
-
 resource "aws_acm_certificate" "integrated_data_acm_certificate" {
   domain_name               = var.domain_name
   subject_alternative_names = ["*.${var.domain_name}"]


### PR DESCRIPTION
Updating the version of TF lint meant having to fix some tf linting issues - hence the code changes. 

Deployed to dev to test pipeline works (runs the same actions as deploy to test and prod): https://github.com/department-for-transport-BODS/bods-integrated-data/actions/runs/26959966796/job/79547560206