### PR TITLE
fix: update input variable reference to avl-pipeline module call

### DIFF
--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -231,7 +231,6 @@ module "integrated_data_avl_pipeline" {
 
   environment                                 = local.env
   vpc_id                                      = module.integrated_data_vpc.vpc_id
-  sg_id                                       = module.integrated_data_vpc.default_sg_id
   private_subnet_ids                          = module.integrated_data_vpc.private_subnet_ids
   db_secret_arn                               = module.integrated_data_aurora_db.db_secret_arn
   db_sg_id                                    = module.integrated_data_aurora_db.db_sg_id


### PR DESCRIPTION
Removing unexpected input variable passed to avl-pipeline module.  This seems to have been removed from dev and test but missed in prod.