### PR TITLE
fix: update naptan uploader for dlz

### DIFF
--- a/src/functions/naptan-uploader/index.test.ts
+++ b/src/functions/naptan-uploader/index.test.ts
@@ -1,10 +1,11 @@
+import { Readable } from "node:stream";
 import { NewNaptanStop, NewNaptanStopArea } from "@bods-integrated-data/shared/database";
 import { describe, expect, it } from "vitest";
-import { parseXml } from ".";
+import { streamAndParseXml } from ".";
 
 describe("naptan-uploader", () => {
-    describe("parseXml", () => {
-        it("parses the XML into a list of stops", () => {
+    describe("streamAndParseXml", () => {
+        it("parses the XML into a list of stops", async () => {
             const xml = `<NaPTAN>
   <StopPoints>
     <StopPoint CreationDateTime="2020-09-09T00:00:00" ModificationDateTime="2020-09-09T08:37:19" Modification="new" RevisionNumber="0" Status="active">
@@ -125,7 +126,7 @@ describe("naptan-uploader", () => {
 	</StopAreas>
 </NaPTAN>`;
 
-            const { stopPoints, stopAreas } = parseXml(xml);
+            const { stopPoints, stopAreas } = await streamAndParseXml(Readable.from([xml]));
             const expectedStopPoints: NewNaptanStop[] = [
                 {
                     administrative_area_code: "151",
@@ -227,7 +228,7 @@ describe("naptan-uploader", () => {
             expect(stopAreas).toEqual(expectedStopAreas);
         });
 
-        it("only sets the stop_area_code property when there is exactly one stop area ref", () => {
+        it("only sets the stop_area_code property when there is exactly one stop area ref", async () => {
             const xml = `<NaPTAN>
 <StopPoints>
   <StopPoint CreationDateTime="2020-09-09T00:00:00" ModificationDateTime="2020-09-09T08:37:19" Modification="new" RevisionNumber="0" Status="active">
@@ -275,7 +276,7 @@ describe("naptan-uploader", () => {
 </StopPoints>
 </NaPTAN>`;
 
-            const { stopPoints } = parseXml(xml);
+            const { stopPoints } = await streamAndParseXml(Readable.from([xml]));
             const expectedStopPoints: NewNaptanStop[] = [
                 {
                     administrative_area_code: "151",

--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -80,11 +80,14 @@ export const streamAndParseXml = async (
     const stopPoints: NewNaptanStop[] = [];
     const stopAreas: NewNaptanStopArea[] = [];
 
-    // Helper to extract text from xml-flow nodes that may have attributes
+    // Helper to extract test from xml-flow
     const getText = (node: any): string | null => {
-        if (!node) return null;
+        if (node == null) return null;
+        if (Array.isArray(node)) return getText(node[0]);
         if (typeof node === "string") return node;
-        if (node.$text) return node.$text;
+        if (typeof node === "number" || typeof node === "boolean") return String(node);
+        if (node.$text != null) return String(node.$text);
+        if (node._ != null) return String(node._);
         return null;
     };
 
@@ -93,9 +96,13 @@ export const streamAndParseXml = async (
 
         // biome-ignore lint/suspicious/noExplicitAny: xml-flow has no TypeScript types
         stream.on("tag:StopPoint", (stop: any) => {
-            const rawRefs = [].concat(stop.StopAreas?.StopAreaRef ?? []);
+            const rawRefs = [].concat(stop.StopAreas?.StopAreaRef ?? stop.StopAreas ?? [])
             const refs: string[] = rawRefs.map((ref: any) => getText(ref)).filter((ref): ref is string => ref !== null);
             const atcoCode = getText(stop.AtcoCode);
+            const locRaw = stop.Place?.Location;
+            const loc = Array.isArray(locRaw) ? locRaw[0] : locRaw;
+            const translationRaw = loc?.Translation;
+            const translation = Array.isArray(translationRaw) ? translationRaw[0] : translationRaw;
             stopPoints.push({
                 atco_code: atcoCode?.toUpperCase() ?? null,
                 naptan_code: getText(stop.NaptanCode) ?? null,
@@ -108,27 +115,36 @@ export const streamAndParseXml = async (
                 crossing: getText(stop.Descriptor?.Crossing) ?? null,
                 indicator: getText(stop.Descriptor?.Indicator) ?? null,
                 bearing:
-                    getText(stop.StopClassification?.OnStreet?.Bus?.MarkedPoint?.Bearing?.CompassPoint) ??
-                    getText(stop.StopClassification?.OnStreet?.Bus?.UnmarkedPoint?.Bearing?.CompassPoint) ??
+                    getText(stop.StopClassification?.OnStreet?.MarkedPoint?.Bearing?.CompassPoint) ??
+                    getText(stop.StopClassification?.OnStreet?.MarkedPoint?.Bearing) ??
+                    getText(stop.StopClassification?.OnStreet?.MarkedPoint?.CompassPoint) ??
+                    getText(stop.StopClassification?.OnStreet?.MarkedPoint) ??
+                    getText(stop.StopClassification?.OnStreet?.UnmarkedPoint?.Bearing?.CompassPoint) ??
+                    getText(stop.StopClassification?.OnStreet?.UnmarkedPoint?.Bearing) ??
+                    getText(stop.StopClassification?.OnStreet?.UnmarkedPoint?.CompassPoint) ??
+                    getText(stop.StopClassification?.OnStreet?.UnmarkedPoint) ??
                     null,
                 nptg_locality_code: getText(stop.Place?.NptgLocalityRef) ?? null,
                 locality_name: getText(stop.Place?.LocalityName) ?? null,
                 town: getText(stop.Place?.Town) ?? null,
                 suburb: getText(stop.Place?.Suburb) ?? null,
                 locality_centre: getText(stop.Place?.LocalityCentre) ?? null,
-                grid_type: getText(stop.Place?.Location?.Translation?.GridType) ?? null,
-                easting: getText(stop.Place?.Location?.Translation?.Easting) || getText(stop.Place?.Location?.Easting) || null,
-                northing: getText(stop.Place?.Location?.Translation?.Northing) || getText(stop.Place?.Location?.Northing) || null,
-                longitude: getText(stop.Place?.Location?.Translation?.Longitude) || getText(stop.Place?.Location?.Longitude) || null,
-                latitude: getText(stop.Place?.Location?.Translation?.Latitude) || getText(stop.Place?.Location?.Latitude) || null,
+                grid_type:
+                    getText(loc?.GridType) ??
+                    getText(translation?.GridType) ??
+                    (typeof translation === "string" ? translation : null),
+                easting: getText(translation?.Easting) || getText(loc?.Easting) || null,
+                northing: getText(translation?.Northing) || getText(loc?.Northing) || null,
+                longitude: getText(translation?.Longitude) || getText(loc?.Longitude) || null,
+                latitude: getText(translation?.Latitude) || getText(loc?.Latitude) || null,
                 stop_type: getText(stop.StopClassification?.StopType) ?? null,
-                bus_stop_type: getText(stop.StopClassification?.OnStreet?.Bus?.BusStopType) ?? null,
+                bus_stop_type: getText(stop.StopClassification?.OnStreet?.BusStopType) ?? null,
                 timing_status:
-                    getText(stop.StopClassification?.OnStreet?.Bus?.TimingStatus) ??
+                    getText(stop.StopClassification?.OnStreet?.TimingStatus) ??
                     getText(stop.StopClassification?.OffStreet?.BusAndCoach?.Bay?.TimingStatus) ??
                     getText(stop.StopClassification?.OffStreet?.BusAndCoach?.VariableBay?.TimingStatus) ??
                     null,
-                default_wait_time: getText(stop.StopClassification?.OnStreet?.Bus?.MarkedPoint?.DefaultWaitTime) ?? null,
+                default_wait_time: getText(stop.StopClassification?.OnStreet?.MarkedPoint?.DefaultWaitTime) ?? null,
                 notes: getText(stop.StopFurtherDetails?.Notes) ?? null,
                 administrative_area_code: getText(stop.AdministrativeAreaRef) ?? null,
                 creation_date_time: null,
@@ -142,19 +158,26 @@ export const streamAndParseXml = async (
 
         // biome-ignore lint/suspicious/noExplicitAny: xml-flow has no TypeScript types
         stream.on("tag:StopArea", (stopArea: any) => {
-            const stopAreaCode = getText(stopArea.StopAreaCode);
-            stopAreas.push({
-                stop_area_code: stopAreaCode?.toUpperCase() ?? null,
-                name: getText(stopArea.Name) ?? null,
-                administrative_area_code: getText(stopArea.AdministrativeAreaRef) ?? null,
-                stop_area_type: getText(stopArea.StopAreaType) ?? null,
-                grid_type: getText(stopArea.Location?.Translation?.GridType) ?? null,
-                easting: getText(stopArea.Location?.Translation?.Easting) ?? null,
-                northing: getText(stopArea.Location?.Translation?.Northing) ?? null,
-                longitude: getText(stopArea.Location?.Translation?.Longitude) ?? null,
-                latitude: getText(stopArea.Location?.Translation?.Latitude) ?? null,
-            });
+        const stopAreaCode = getText(stopArea.StopAreaCode);
+        const areaLocRaw = stopArea.Location;
+        const areaLoc = Array.isArray(areaLocRaw) ? areaLocRaw[0] : areaLocRaw;
+        const areaTranslationRaw = areaLoc?.Translation;
+        const areaTranslation = Array.isArray(areaTranslationRaw) ? areaTranslationRaw[0] : areaTranslationRaw;
+        stopAreas.push({
+            stop_area_code: stopAreaCode?.toUpperCase() ?? null,
+            name: getText(stopArea.Name) ?? null,
+            administrative_area_code: getText(stopArea.AdministrativeAreaRef) ?? null,
+            stop_area_type: getText(stopArea.StopAreaType) ?? null,
+            grid_type:
+                getText(areaLoc?.GridType) ??
+                getText(areaTranslation?.GridType) ??
+                (typeof areaTranslation === "string" ? areaTranslation : null),
+            easting: getText(areaTranslation?.Easting) ?? getText(areaLoc?.Easting) ?? null,
+            northing: getText(areaTranslation?.Northing) ?? getText(areaLoc?.Northing) ?? null,
+            longitude: getText(areaTranslation?.Longitude) ?? getText(areaLoc?.Longitude) ?? null,
+            latitude: getText(areaTranslation?.Latitude) ?? getText(areaLoc?.Latitude) ?? null,
         });
+    });
 
         stream.on("error", reject);
         stream.on("end", resolve);

--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -109,7 +109,7 @@ const mapStopPoint = (stop: XmlNode): NewNaptanStop => {
         .filter((ref): ref is string => ref !== null);
 
     return {
-        atco_code: getText(getChild(stop, "AtcoCode"))?.toUpperCase() ?? null,
+        atco_code: getText(getChild(stop, "AtcoCode"))?.toUpperCase() ?? "",
         naptan_code: getText(getChild(stop, "NaptanCode")),
         plate_code: getText(getChild(stop, "PlateCode")),
         cleardown_code: getText(getChild(stop, "CleardownCode")),
@@ -155,10 +155,10 @@ const mapStopArea = (stopArea: XmlNode): NewNaptanStopArea => {
     const translation = getChild(location, "Translation");
 
     return {
-        stop_area_code: getText(getChild(stopArea, "StopAreaCode"))?.toUpperCase() ?? null,
-        name: getText(getChild(stopArea, "Name")),
-        administrative_area_code: getText(getChild(stopArea, "AdministrativeAreaRef")),
-        stop_area_type: getText(getChild(stopArea, "StopAreaType")),
+        stop_area_code: getText(getChild(stopArea, "StopAreaCode"))?.toUpperCase() ?? "",
+        name: getText(getChild(stopArea, "Name")) ?? "",
+        administrative_area_code: getText(getChild(stopArea, "AdministrativeAreaRef")) ?? "",
+        stop_area_type: getText(getChild(stopArea, "StopAreaType")) ?? "",
         grid_type: getText(getChild(translation, "GridType")) ?? getText(getChild(location, "GridType")),
         easting: getText(getChild(translation, "Easting")) ?? getText(getChild(location, "Easting")),
         northing: getText(getChild(translation, "Northing")) ?? getText(getChild(location, "Northing")),
@@ -206,7 +206,7 @@ export const streamAndParseXml = async (
                 current.text += text;
             }
         });
-        
+
         saxStream.on("closetag", (tagName) => {
             if (!capturing) {
                 return;

--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -199,7 +199,7 @@ export const streamAndParseXml = async (
             stack[stack.length - 1]?.children.push(node);
             stack.push(node);
         });
-        
+
         saxStream.on("text", (text) => {
             const current = stack[stack.length - 1];
             if (current) {
@@ -207,7 +207,7 @@ export const streamAndParseXml = async (
             }
         });
 
-        saxStream.on("closetag", (tagName) => {
+        saxStream.on("closetag", (_tagName) => {
             if (!capturing) {
                 return;
             }

--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -1,3 +1,4 @@
+import { Readable } from "node:stream";
 import { S3Client } from "@aws-sdk/client-s3";
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 import {
@@ -10,93 +11,15 @@ import {
 } from "@bods-integrated-data/shared/database";
 import { errorMapWithDataLogging, logger, withLambdaRequestTracker } from "@bods-integrated-data/shared/logger";
 import { getS3Object } from "@bods-integrated-data/shared/s3";
-import { naptanSchema } from "@bods-integrated-data/shared/schema/naptan.schema";
 import { S3Handler } from "aws-lambda";
 import { Promise as BluebirdPromise } from "bluebird";
-import { XMLParser } from "fast-xml-parser";
 import OsPoint from "ospoint";
+import xmlFlow from "xml-flow";
 import { z } from "zod";
 
 z.setErrorMap(errorMapWithDataLogging);
 
 let dbClient: KyselyDb;
-
-const arrayProperties = ["StopPoint", "StopArea", "StopAreaRef"];
-
-export const parseXml = (xml: string) => {
-    const parser = new XMLParser({
-        allowBooleanAttributes: true,
-        ignoreAttributes: true,
-        parseTagValue: false,
-        isArray: (tagName) => arrayProperties.includes(tagName),
-    });
-
-    const parsedXml = parser.parse(xml);
-    const parsedNaptanData = naptanSchema.parse(parsedXml);
-
-    const stopPoints = parsedNaptanData.NaPTAN.StopPoints.StopPoint.map<NewNaptanStop>((stop) => {
-        return {
-            atco_code: stop.AtcoCode.toUpperCase(),
-            naptan_code: stop.NaptanCode ?? null,
-            plate_code: stop.PlateCode ?? null,
-            cleardown_code: stop.CleardownCode ?? null,
-            common_name: stop.Descriptor.CommonName ?? null,
-            short_common_name: stop.Descriptor.ShortCommonName ?? null,
-            landmark: stop.Descriptor.Landmark ?? null,
-            street: stop.Descriptor.Street ?? null,
-            crossing: stop.Descriptor.Crossing ?? null,
-            indicator: stop.Descriptor.Indicator ?? null,
-            bearing:
-                stop.StopClassification.OnStreet?.Bus?.MarkedPoint?.Bearing.CompassPoint ??
-                stop.StopClassification.OnStreet?.Bus?.UnmarkedPoint?.Bearing.CompassPoint ??
-                null,
-            nptg_locality_code: stop.Place.NptgLocalityRef,
-            locality_name: stop.Place.LocalityName ?? null,
-            town: stop.Place.Town ?? null,
-            suburb: stop.Place.Suburb ?? null,
-            locality_centre: stop.Place.LocalityCentre ?? null,
-            grid_type: stop.Place.Location.Translation?.GridType ?? null,
-            easting: stop.Place.Location.Translation?.Easting || stop.Place.Location.Easting || null,
-            northing: stop.Place.Location.Translation?.Northing || stop.Place.Location.Northing || null,
-            longitude: stop.Place.Location.Translation?.Longitude || stop.Place.Location.Longitude || null,
-            latitude: stop.Place.Location.Translation?.Latitude || stop.Place.Location.Latitude || null,
-            stop_type: stop.StopClassification.StopType,
-            bus_stop_type: stop.StopClassification.OnStreet?.Bus?.BusStopType,
-            timing_status:
-                stop.StopClassification.OnStreet?.Bus?.TimingStatus ??
-                stop.StopClassification.OffStreet?.BusAndCoach?.Bay?.TimingStatus ??
-                stop.StopClassification.OffStreet?.BusAndCoach?.VariableBay?.TimingStatus ??
-                null,
-            default_wait_time: stop.StopClassification.OnStreet?.Bus?.MarkedPoint?.DefaultWaitTime ?? null,
-            notes: stop.StopFurtherDetails?.Notes ?? null,
-            administrative_area_code: stop.AdministrativeAreaRef,
-            creation_date_time: null,
-            modification_date_time: null,
-            revision_number: null,
-            modification: null,
-            status: null,
-            stop_area_code:
-                stop.StopAreas?.StopAreaRef?.length === 1 ? stop.StopAreas.StopAreaRef[0].toUpperCase() : null,
-        };
-    });
-
-    const stopAreas =
-        parsedNaptanData.NaPTAN.StopAreas?.StopArea.map<NewNaptanStopArea>((stopArea) => {
-            return {
-                stop_area_code: stopArea.StopAreaCode.toUpperCase(),
-                name: stopArea.Name,
-                administrative_area_code: stopArea.AdministrativeAreaRef,
-                stop_area_type: stopArea.StopAreaType,
-                grid_type: stopArea.Location.Translation?.GridType ?? null,
-                easting: stopArea.Location.Translation?.Easting ?? null,
-                northing: stopArea.Location.Translation?.Northing ?? null,
-                longitude: stopArea.Location.Translation?.Longitude ?? null,
-                latitude: stopArea.Location.Translation?.Latitude ?? null,
-            };
-        }) ?? [];
-
-    return { stopPoints, stopAreas };
-};
 
 // cross-account S3 for Naptan update
 const getCrossAccountS3Client = async (roleArn: string, region: string) => {
@@ -129,6 +52,117 @@ const getCrossAccountS3Client = async (roleArn: string, region: string) => {
     });
 };
 
+const streamAndParseNaptanFile = async (
+    bucketName: string,
+    s3Key: string,
+    crossAccountRoleArn: string,
+    region: string,
+): Promise<{ stopPoints: NewNaptanStop[]; stopAreas: NewNaptanStopArea[] }> => {
+    const s3Client = await getCrossAccountS3Client(crossAccountRoleArn, region);
+    const file = await getS3Object(
+        {
+            Bucket: bucketName,
+            Key: s3Key,
+        },
+        s3Client,
+    );
+
+    if (!file.Body) {
+        throw new Error(`No body returned for s3://${bucketName}/${s3Key}`);
+    }
+
+    return streamAndParseXml(file.Body as Readable);
+};
+
+export const streamAndParseXml = async (
+    readable: Readable,
+): Promise<{ stopPoints: NewNaptanStop[]; stopAreas: NewNaptanStopArea[] }> => {
+    const stopPoints: NewNaptanStop[] = [];
+    const stopAreas: NewNaptanStopArea[] = [];
+
+    // Helper to extract text from xml-flow nodes that may have attributes
+    const getText = (node: any): string | null => {
+        if (!node) return null;
+        if (typeof node === "string") return node;
+        if (node.$text) return node.$text;
+        return null;
+    };
+
+    await new Promise<void>((resolve, reject) => {
+        const stream = xmlFlow(readable, { strict: true, preserveMarkup: xmlFlow.NEVER, trim: true });
+
+        // biome-ignore lint/suspicious/noExplicitAny: xml-flow has no TypeScript types
+        stream.on("tag:StopPoint", (stop: any) => {
+            const rawRefs = [].concat(stop.StopAreas?.StopAreaRef ?? []);
+            const refs: string[] = rawRefs.map((ref: any) => getText(ref)).filter((ref): ref is string => ref !== null);
+            const atcoCode = getText(stop.AtcoCode);
+            stopPoints.push({
+                atco_code: atcoCode?.toUpperCase() ?? null,
+                naptan_code: getText(stop.NaptanCode) ?? null,
+                plate_code: getText(stop.PlateCode) ?? null,
+                cleardown_code: getText(stop.CleardownCode) ?? null,
+                common_name: getText(stop.Descriptor?.CommonName) ?? null,
+                short_common_name: getText(stop.Descriptor?.ShortCommonName) ?? null,
+                landmark: getText(stop.Descriptor?.Landmark) ?? null,
+                street: getText(stop.Descriptor?.Street) ?? null,
+                crossing: getText(stop.Descriptor?.Crossing) ?? null,
+                indicator: getText(stop.Descriptor?.Indicator) ?? null,
+                bearing:
+                    getText(stop.StopClassification?.OnStreet?.Bus?.MarkedPoint?.Bearing?.CompassPoint) ??
+                    getText(stop.StopClassification?.OnStreet?.Bus?.UnmarkedPoint?.Bearing?.CompassPoint) ??
+                    null,
+                nptg_locality_code: getText(stop.Place?.NptgLocalityRef) ?? null,
+                locality_name: getText(stop.Place?.LocalityName) ?? null,
+                town: getText(stop.Place?.Town) ?? null,
+                suburb: getText(stop.Place?.Suburb) ?? null,
+                locality_centre: getText(stop.Place?.LocalityCentre) ?? null,
+                grid_type: getText(stop.Place?.Location?.Translation?.GridType) ?? null,
+                easting: getText(stop.Place?.Location?.Translation?.Easting) || getText(stop.Place?.Location?.Easting) || null,
+                northing: getText(stop.Place?.Location?.Translation?.Northing) || getText(stop.Place?.Location?.Northing) || null,
+                longitude: getText(stop.Place?.Location?.Translation?.Longitude) || getText(stop.Place?.Location?.Longitude) || null,
+                latitude: getText(stop.Place?.Location?.Translation?.Latitude) || getText(stop.Place?.Location?.Latitude) || null,
+                stop_type: getText(stop.StopClassification?.StopType) ?? null,
+                bus_stop_type: getText(stop.StopClassification?.OnStreet?.Bus?.BusStopType) ?? null,
+                timing_status:
+                    getText(stop.StopClassification?.OnStreet?.Bus?.TimingStatus) ??
+                    getText(stop.StopClassification?.OffStreet?.BusAndCoach?.Bay?.TimingStatus) ??
+                    getText(stop.StopClassification?.OffStreet?.BusAndCoach?.VariableBay?.TimingStatus) ??
+                    null,
+                default_wait_time: getText(stop.StopClassification?.OnStreet?.Bus?.MarkedPoint?.DefaultWaitTime) ?? null,
+                notes: getText(stop.StopFurtherDetails?.Notes) ?? null,
+                administrative_area_code: getText(stop.AdministrativeAreaRef) ?? null,
+                creation_date_time: null,
+                modification_date_time: null,
+                revision_number: null,
+                modification: null,
+                status: null,
+                stop_area_code: refs.length === 1 ? refs[0].toUpperCase() : null,
+            });
+        });
+
+        // biome-ignore lint/suspicious/noExplicitAny: xml-flow has no TypeScript types
+        stream.on("tag:StopArea", (stopArea: any) => {
+            const stopAreaCode = getText(stopArea.StopAreaCode);
+            stopAreas.push({
+                stop_area_code: stopAreaCode?.toUpperCase() ?? null,
+                name: getText(stopArea.Name) ?? null,
+                administrative_area_code: getText(stopArea.AdministrativeAreaRef) ?? null,
+                stop_area_type: getText(stopArea.StopAreaType) ?? null,
+                grid_type: getText(stopArea.Location?.Translation?.GridType) ?? null,
+                easting: getText(stopArea.Location?.Translation?.Easting) ?? null,
+                northing: getText(stopArea.Location?.Translation?.Northing) ?? null,
+                longitude: getText(stopArea.Location?.Translation?.Longitude) ?? null,
+                latitude: getText(stopArea.Location?.Translation?.Latitude) ?? null,
+            });
+        });
+
+        stream.on("error", reject);
+        stream.on("end", resolve);
+    });
+
+    return { stopPoints, stopAreas };
+};
+
 const addLonAndLatData = (naptanData: unknown[]) => {
     return (
         naptanData as {
@@ -156,26 +190,6 @@ const addLonAndLatData = (naptanData: unknown[]) => {
             ...item,
         };
     });
-};
-
-const getAndParseNaptanFile = async (
-    bucketName: string,
-    s3Key: string,
-    crossAccountRoleArn: string,
-    region: string,
-) => {
-    const s3Client = await getCrossAccountS3Client(crossAccountRoleArn, region);
-
-    const file = await getS3Object(
-        {
-            Bucket: bucketName,
-            Key: s3Key,
-        },
-        s3Client,
-    );
-
-    const body = (await file.Body?.transformToString()) || "";
-    return parseXml(body);
 };
 
 const insertNaptanData = async (dbClient: KyselyDb, naptanStops: unknown[], naptanStopAreas: unknown[]) => {
@@ -261,7 +275,7 @@ export const handler: S3Handler = async (event, context) => {
             throw new Error("NAPTAN_S3_KEY environment variable must be set");
         }
 
-        const { stopPoints, stopAreas } = await getAndParseNaptanFile(
+        const { stopPoints, stopAreas } = await streamAndParseNaptanFile(
             externalBucketName,
             naptanS3Key,
             crossAccountRoleArn,

--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -14,7 +14,7 @@ import { getS3Object } from "@bods-integrated-data/shared/s3";
 import { S3Handler } from "aws-lambda";
 import { Promise as BluebirdPromise } from "bluebird";
 import OsPoint from "ospoint";
-import xmlFlow from "xml-flow";
+import sax from "sax";
 import { z } from "zod";
 
 z.setErrorMap(errorMapWithDataLogging);
@@ -74,116 +74,161 @@ const streamAndParseNaptanFile = async (
     return streamAndParseXml(file.Body as Readable);
 };
 
+interface XmlNode {
+    name: string;
+    attributes: Record<string, string>;
+    children: XmlNode[];
+    text: string;
+}
+
+const getChild = (node: XmlNode | undefined, name: string): XmlNode | undefined =>
+    node?.children.find((child) => child.name === name);
+
+const getChildren = (node: XmlNode | undefined, name: string): XmlNode[] =>
+    node?.children.filter((child) => child.name === name) ?? [];
+
+const getPath = (node: XmlNode | undefined, ...names: string[]): XmlNode | undefined =>
+    names.reduce<XmlNode | undefined>((current, name) => getChild(current, name), node);
+
+const getText = (node: XmlNode | undefined): string | null => {
+    const trimmed = node?.text.trim();
+    return trimmed ? trimmed : null;
+};
+
+const mapStopPoint = (stop: XmlNode): NewNaptanStop => {
+    const descriptor = getChild(stop, "Descriptor");
+    const place = getChild(stop, "Place");
+    const location = getChild(place, "Location");
+    const translation = getChild(location, "Translation");
+    const classification = getChild(stop, "StopClassification");
+    const onStreet = getChild(classification, "OnStreet");
+    const bus = getChild(onStreet, "Bus");
+    const markedPoint = getChild(bus, "MarkedPoint");
+    const refs = getChildren(getChild(stop, "StopAreas"), "StopAreaRef")
+        .map(getText)
+        .filter((ref): ref is string => ref !== null);
+
+    return {
+        atco_code: getText(getChild(stop, "AtcoCode"))?.toUpperCase() ?? null,
+        naptan_code: getText(getChild(stop, "NaptanCode")),
+        plate_code: getText(getChild(stop, "PlateCode")),
+        cleardown_code: getText(getChild(stop, "CleardownCode")),
+        common_name: getText(getChild(descriptor, "CommonName")),
+        short_common_name: getText(getChild(descriptor, "ShortCommonName")),
+        landmark: getText(getChild(descriptor, "Landmark")),
+        street: getText(getChild(descriptor, "Street")),
+        crossing: getText(getChild(descriptor, "Crossing")),
+        indicator: getText(getChild(descriptor, "Indicator")),
+        bearing:
+            getText(getPath(markedPoint, "Bearing", "CompassPoint")) ??
+            getText(getPath(bus, "UnmarkedPoint", "Bearing", "CompassPoint")),
+        nptg_locality_code: getText(getChild(place, "NptgLocalityRef")),
+        locality_name: getText(getChild(place, "LocalityName")),
+        town: getText(getChild(place, "Town")),
+        suburb: getText(getChild(place, "Suburb")),
+        locality_centre: getText(getChild(place, "LocalityCentre")),
+        grid_type: getText(getChild(translation, "GridType")) ?? getText(getChild(location, "GridType")),
+        easting: getText(getChild(translation, "Easting")) ?? getText(getChild(location, "Easting")),
+        northing: getText(getChild(translation, "Northing")) ?? getText(getChild(location, "Northing")),
+        longitude: getText(getChild(translation, "Longitude")) ?? getText(getChild(location, "Longitude")),
+        latitude: getText(getChild(translation, "Latitude")) ?? getText(getChild(location, "Latitude")),
+        stop_type: getText(getChild(classification, "StopType")),
+        bus_stop_type: getText(getChild(bus, "BusStopType")),
+        timing_status:
+            getText(getChild(bus, "TimingStatus")) ??
+            getText(getPath(classification, "OffStreet", "BusAndCoach", "Bay", "TimingStatus")) ??
+            getText(getPath(classification, "OffStreet", "BusAndCoach", "VariableBay", "TimingStatus")),
+        default_wait_time: getText(getChild(markedPoint, "DefaultWaitTime")),
+        notes: getText(getPath(stop, "StopFurtherDetails", "Notes")),
+        administrative_area_code: getText(getChild(stop, "AdministrativeAreaRef")),
+        creation_date_time: null,
+        modification_date_time: null,
+        revision_number: null,
+        modification: null,
+        status: null,
+        stop_area_code: refs.length === 1 ? refs[0].toUpperCase() : null,
+    };
+};
+
+const mapStopArea = (stopArea: XmlNode): NewNaptanStopArea => {
+    const location = getChild(stopArea, "Location");
+    const translation = getChild(location, "Translation");
+
+    return {
+        stop_area_code: getText(getChild(stopArea, "StopAreaCode"))?.toUpperCase() ?? null,
+        name: getText(getChild(stopArea, "Name")),
+        administrative_area_code: getText(getChild(stopArea, "AdministrativeAreaRef")),
+        stop_area_type: getText(getChild(stopArea, "StopAreaType")),
+        grid_type: getText(getChild(translation, "GridType")) ?? getText(getChild(location, "GridType")),
+        easting: getText(getChild(translation, "Easting")) ?? getText(getChild(location, "Easting")),
+        northing: getText(getChild(translation, "Northing")) ?? getText(getChild(location, "Northing")),
+        longitude: getText(getChild(translation, "Longitude")) ?? getText(getChild(location, "Longitude")),
+        latitude: getText(getChild(translation, "Latitude")) ?? getText(getChild(location, "Latitude")),
+    };
+};
+
 export const streamAndParseXml = async (
     readable: Readable,
 ): Promise<{ stopPoints: NewNaptanStop[]; stopAreas: NewNaptanStopArea[] }> => {
-    const stopPoints: NewNaptanStop[] = [];
-    const stopAreas: NewNaptanStopArea[] = [];
+    return new Promise((resolve, reject) => {
+        const stopPoints: NewNaptanStop[] = [];
+        const stopAreas: NewNaptanStopArea[] = [];
 
-    // Helper to extract test from xml-flow
-    const getText = (node: any): string | null => {
-        if (node == null) return null;
-        if (Array.isArray(node)) return getText(node[0]);
-        if (typeof node === "string") return node;
-        if (typeof node === "number" || typeof node === "boolean") return String(node);
-        if (node.$text != null) return String(node.$text);
-        if (node._ != null) return String(node._);
-        return null;
-    };
+        const saxStream = sax.createStream(true, { trim: true });
+        const stack: XmlNode[] = [];
+        let capturing: "StopPoint" | "StopArea" | null = null;
 
-    await new Promise<void>((resolve, reject) => {
-        const stream = xmlFlow(readable, { strict: true, preserveMarkup: xmlFlow.NEVER, trim: true });
+        saxStream.on("opentag", (tag) => {
+            if (!capturing) {
+                if (tag.name === "StopPoint") {
+                    capturing = "StopPoint";
+                } else if (tag.name === "StopArea") {
+                    capturing = "StopArea";
+                } else {
+                    return;
+                }
+            }
 
-        // biome-ignore lint/suspicious/noExplicitAny: xml-flow has no TypeScript types
-        stream.on("tag:StopPoint", (stop: any) => {
-            const rawRefs = [].concat(stop.StopAreas?.StopAreaRef ?? stop.StopAreas ?? [])
-            const refs: string[] = rawRefs.map((ref: any) => getText(ref)).filter((ref): ref is string => ref !== null);
-            const atcoCode = getText(stop.AtcoCode);
-            const locRaw = stop.Place?.Location;
-            const loc = Array.isArray(locRaw) ? locRaw[0] : locRaw;
-            const translationRaw = loc?.Translation;
-            const translation = Array.isArray(translationRaw) ? translationRaw[0] : translationRaw;
-            stopPoints.push({
-                atco_code: atcoCode?.toUpperCase() ?? null,
-                naptan_code: getText(stop.NaptanCode) ?? null,
-                plate_code: getText(stop.PlateCode) ?? null,
-                cleardown_code: getText(stop.CleardownCode) ?? null,
-                common_name: getText(stop.Descriptor?.CommonName) ?? null,
-                short_common_name: getText(stop.Descriptor?.ShortCommonName) ?? null,
-                landmark: getText(stop.Descriptor?.Landmark) ?? null,
-                street: getText(stop.Descriptor?.Street) ?? null,
-                crossing: getText(stop.Descriptor?.Crossing) ?? null,
-                indicator: getText(stop.Descriptor?.Indicator) ?? null,
-                bearing:
-                    getText(stop.StopClassification?.OnStreet?.MarkedPoint?.Bearing?.CompassPoint) ??
-                    getText(stop.StopClassification?.OnStreet?.MarkedPoint?.Bearing) ??
-                    getText(stop.StopClassification?.OnStreet?.MarkedPoint?.CompassPoint) ??
-                    getText(stop.StopClassification?.OnStreet?.MarkedPoint) ??
-                    getText(stop.StopClassification?.OnStreet?.UnmarkedPoint?.Bearing?.CompassPoint) ??
-                    getText(stop.StopClassification?.OnStreet?.UnmarkedPoint?.Bearing) ??
-                    getText(stop.StopClassification?.OnStreet?.UnmarkedPoint?.CompassPoint) ??
-                    getText(stop.StopClassification?.OnStreet?.UnmarkedPoint) ??
-                    null,
-                nptg_locality_code: getText(stop.Place?.NptgLocalityRef) ?? null,
-                locality_name: getText(stop.Place?.LocalityName) ?? null,
-                town: getText(stop.Place?.Town) ?? null,
-                suburb: getText(stop.Place?.Suburb) ?? null,
-                locality_centre: getText(stop.Place?.LocalityCentre) ?? null,
-                grid_type:
-                    getText(loc?.GridType) ??
-                    getText(translation?.GridType) ??
-                    (typeof translation === "string" ? translation : null),
-                easting: getText(translation?.Easting) || getText(loc?.Easting) || null,
-                northing: getText(translation?.Northing) || getText(loc?.Northing) || null,
-                longitude: getText(translation?.Longitude) || getText(loc?.Longitude) || null,
-                latitude: getText(translation?.Latitude) || getText(loc?.Latitude) || null,
-                stop_type: getText(stop.StopClassification?.StopType) ?? null,
-                bus_stop_type: getText(stop.StopClassification?.OnStreet?.BusStopType) ?? null,
-                timing_status:
-                    getText(stop.StopClassification?.OnStreet?.TimingStatus) ??
-                    getText(stop.StopClassification?.OffStreet?.BusAndCoach?.Bay?.TimingStatus) ??
-                    getText(stop.StopClassification?.OffStreet?.BusAndCoach?.VariableBay?.TimingStatus) ??
-                    null,
-                default_wait_time: getText(stop.StopClassification?.OnStreet?.MarkedPoint?.DefaultWaitTime) ?? null,
-                notes: getText(stop.StopFurtherDetails?.Notes) ?? null,
-                administrative_area_code: getText(stop.AdministrativeAreaRef) ?? null,
-                creation_date_time: null,
-                modification_date_time: null,
-                revision_number: null,
-                modification: null,
-                status: null,
-                stop_area_code: refs.length === 1 ? refs[0].toUpperCase() : null,
-            });
+            const node: XmlNode = {
+                name: tag.name,
+                attributes: tag.attributes as Record<string, string>,
+                children: [],
+                text: "",
+            };
+
+            stack[stack.length - 1]?.children.push(node);
+            stack.push(node);
+        });
+        
+        saxStream.on("text", (text) => {
+            const current = stack[stack.length - 1];
+            if (current) {
+                current.text += text;
+            }
+        });
+        
+        saxStream.on("closetag", (tagName) => {
+            if (!capturing) {
+                return;
+            }
+
+            const node = stack.pop();
+
+            if (stack.length === 0 && node) {
+                if (capturing === "StopPoint") {
+                    stopPoints.push(mapStopPoint(node));
+                } else {
+                    stopAreas.push(mapStopArea(node));
+                }
+                capturing = null;
+            }
         });
 
-        // biome-ignore lint/suspicious/noExplicitAny: xml-flow has no TypeScript types
-        stream.on("tag:StopArea", (stopArea: any) => {
-        const stopAreaCode = getText(stopArea.StopAreaCode);
-        const areaLocRaw = stopArea.Location;
-        const areaLoc = Array.isArray(areaLocRaw) ? areaLocRaw[0] : areaLocRaw;
-        const areaTranslationRaw = areaLoc?.Translation;
-        const areaTranslation = Array.isArray(areaTranslationRaw) ? areaTranslationRaw[0] : areaTranslationRaw;
-        stopAreas.push({
-            stop_area_code: stopAreaCode?.toUpperCase() ?? null,
-            name: getText(stopArea.Name) ?? null,
-            administrative_area_code: getText(stopArea.AdministrativeAreaRef) ?? null,
-            stop_area_type: getText(stopArea.StopAreaType) ?? null,
-            grid_type:
-                getText(areaLoc?.GridType) ??
-                getText(areaTranslation?.GridType) ??
-                (typeof areaTranslation === "string" ? areaTranslation : null),
-            easting: getText(areaTranslation?.Easting) ?? getText(areaLoc?.Easting) ?? null,
-            northing: getText(areaTranslation?.Northing) ?? getText(areaLoc?.Northing) ?? null,
-            longitude: getText(areaTranslation?.Longitude) ?? getText(areaLoc?.Longitude) ?? null,
-            latitude: getText(areaTranslation?.Latitude) ?? getText(areaLoc?.Latitude) ?? null,
-        });
-    });
+        saxStream.on("error", reject);
+        saxStream.on("end", () => resolve({ stopPoints, stopAreas }));
 
-        stream.on("error", reject);
-        stream.on("end", resolve);
+        readable.pipe(saxStream);
     });
-
-    return { stopPoints, stopAreas };
 };
 
 const addLonAndLatData = (naptanData: unknown[]) => {

--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -177,7 +177,7 @@ const mapStopArea = (stopArea: XmlNode): NewNaptanStopArea => {
     }
 
     const stopAreaType = getText(getChild(stopArea, "StopAreaType"));
-    
+
     if (!stopAreaType) {
         throw new Error("StopArea missing StopAreaType");
     }

--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -107,9 +107,14 @@ const mapStopPoint = (stop: XmlNode): NewNaptanStop => {
     const refs = getChildren(getChild(stop, "StopAreas"), "StopAreaRef")
         .map(getText)
         .filter((ref): ref is string => ref !== null);
+    const atcoCode = getText(getChild(stop, "AtcoCode"));
+
+    if (!atcoCode) {
+        throw new Error("StopPoint missing AtcoCode");
+    }
 
     return {
-        atco_code: getText(getChild(stop, "AtcoCode"))?.toUpperCase() ?? "",
+        atco_code: atcoCode.toUpperCase(),
         naptan_code: getText(getChild(stop, "NaptanCode")),
         plate_code: getText(getChild(stop, "PlateCode")),
         cleardown_code: getText(getChild(stop, "CleardownCode")),
@@ -153,12 +158,35 @@ const mapStopPoint = (stop: XmlNode): NewNaptanStop => {
 const mapStopArea = (stopArea: XmlNode): NewNaptanStopArea => {
     const location = getChild(stopArea, "Location");
     const translation = getChild(location, "Translation");
+    const stopAreaCode = getText(getChild(stopArea, "StopAreaCode"));
+
+    if (!stopAreaCode) {
+        throw new Error("StopArea missing StopAreaCode");
+    }
+
+    const name = getText(getChild(stopArea, "Name"));
+
+    if (!name) {
+        throw new Error("StopArea missing Name");
+    }
+
+    const administrativeAreaCode = getText(getChild(stopArea, "AdministrativeAreaRef"));
+
+    if (!administrativeAreaCode) {
+        throw new Error("StopArea missing AdministrativeAreaRef");
+    }
+
+    const stopAreaType = getText(getChild(stopArea, "StopAreaType"));
+    
+    if (!stopAreaType) {
+        throw new Error("StopArea missing StopAreaType");
+    }
 
     return {
-        stop_area_code: getText(getChild(stopArea, "StopAreaCode"))?.toUpperCase() ?? "",
-        name: getText(getChild(stopArea, "Name")) ?? "",
-        administrative_area_code: getText(getChild(stopArea, "AdministrativeAreaRef")) ?? "",
-        stop_area_type: getText(getChild(stopArea, "StopAreaType")) ?? "",
+        stop_area_code: stopAreaCode.toUpperCase(),
+        name,
+        administrative_area_code: administrativeAreaCode,
+        stop_area_type: stopAreaType,
         grid_type: getText(getChild(translation, "GridType")) ?? getText(getChild(location, "GridType")),
         easting: getText(getChild(translation, "Easting")) ?? getText(getChild(location, "Easting")),
         northing: getText(getChild(translation, "Northing")) ?? getText(getChild(location, "Northing")),

--- a/src/functions/naptan-uploader/package.json
+++ b/src/functions/naptan-uploader/package.json
@@ -16,11 +16,11 @@
         "@aws-sdk/client-secrets-manager": "^3.682.0",
         "@bods-integrated-data/shared": "workspace:^",
         "bluebird": "^3.7.2",
-        "fast-xml-parser": "5.3.5",
         "kysely": "^0.27.3",
         "ospoint": "^0.2.1",
         "papaparse": "^5.4.1",
         "pg": "^8.11.3",
+        "xml-flow": "^1.0.4",
         "zod": "3.23.8"
     },
     "devDependencies": {

--- a/src/functions/naptan-uploader/package.json
+++ b/src/functions/naptan-uploader/package.json
@@ -20,7 +20,7 @@
         "ospoint": "^0.2.1",
         "papaparse": "^5.4.1",
         "pg": "^8.11.3",
-        "xml-flow": "^1.0.4",
+        "sax": "^1.2.4",
         "zod": "3.23.8"
     },
     "devDependencies": {
@@ -28,6 +28,7 @@
         "@types/bluebird": "^3.5.42",
         "@types/node": "^20.11.19",
         "@types/papaparse": "^5.3.14",
-        "@types/pg": "^8.11.0"
+        "@types/pg": "^8.11.0",
+        "@types/sax": "^1.2.7"
     }
 }

--- a/src/functions/naptan-uploader/pnpm-lock.yaml
+++ b/src/functions/naptan-uploader/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       bluebird:
         specifier: ^3.7.2
         version: 3.7.2
-      fast-xml-parser:
-        specifier: 5.3.5
-        version: 5.3.5
       kysely:
         specifier: ^0.27.3
         version: 0.27.3
@@ -35,6 +32,9 @@ importers:
       pg:
         specifier: ^8.11.3
         version: 8.11.3
+      xml-flow:
+        specifier: ^1.0.4
+        version: 1.0.4
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -475,10 +475,6 @@ packages:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
 
-  fast-xml-parser@5.3.5:
-    resolution: {integrity: sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==}
-    hasBin: true
-
   kysely@0.27.3:
     resolution: {integrity: sha512-lG03Ru+XyOJFsjH3OMY6R/9U38IjDPfnOfDgO3ynhbDr+Dz8fak+X6L62vqu3iybQnj+lG84OttBuU9KY3L9kA==}
     engines: {node: '>=14.0.0'}
@@ -572,15 +568,16 @@ packages:
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
-
-  strnum@2.2.2:
-    resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
@@ -592,6 +589,9 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  xml-flow@1.0.4:
+    resolution: {integrity: sha512-r19LXKPL7vkVGL6oWHlESoBgwUVom5w/w8opuS53qULh8+K2w+K9K72edTIQa+X/Vxx1R7ugnCabHFSZ1Tv2zA==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -1535,10 +1535,6 @@ snapshots:
     dependencies:
       strnum: 1.1.2
 
-  fast-xml-parser@5.3.5:
-    dependencies:
-      strnum: 2.2.2
-
   kysely@0.27.3: {}
 
   obuf@1.1.2: {}
@@ -1620,17 +1616,21 @@ snapshots:
 
   postgres-range@1.1.4: {}
 
+  sax@1.6.0: {}
+
   split2@4.2.0: {}
 
   strnum@1.1.2: {}
-
-  strnum@2.2.2: {}
 
   tslib@2.6.2: {}
 
   undici-types@5.26.5: {}
 
   uuid@9.0.1: {}
+
+  xml-flow@1.0.4:
+    dependencies:
+      sax: 1.6.0
 
   xtend@4.0.2: {}
 

--- a/src/functions/naptan-uploader/pnpm-lock.yaml
+++ b/src/functions/naptan-uploader/pnpm-lock.yaml
@@ -32,9 +32,9 @@ importers:
       pg:
         specifier: ^8.11.3
         version: 8.11.3
-      xml-flow:
-        specifier: ^1.0.4
-        version: 1.0.4
+      sax:
+        specifier: ^1.2.4
+        version: 1.6.0
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -54,6 +54,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.11.0
+      '@types/sax':
+        specifier: ^1.2.7
+        version: 1.2.7
 
 packages:
 
@@ -458,6 +461,9 @@ packages:
   '@types/pg@8.11.0':
     resolution: {integrity: sha512-sDAlRiBNthGjNFfvt0k6mtotoVYVQ63pA8R4EMWka7crawSR60waVYR0HAgmPRs/e2YaeJTD/43OoZ3PFw80pw==}
 
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
@@ -589,9 +595,6 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
-
-  xml-flow@1.0.4:
-    resolution: {integrity: sha512-r19LXKPL7vkVGL6oWHlESoBgwUVom5w/w8opuS53qULh8+K2w+K9K72edTIQa+X/Vxx1R7ugnCabHFSZ1Tv2zA==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -1523,6 +1526,10 @@ snapshots:
       pg-protocol: 1.6.0
       pg-types: 4.0.2
 
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 20.11.19
+
   '@types/uuid@9.0.8': {}
 
   bluebird@3.7.2: {}
@@ -1627,10 +1634,6 @@ snapshots:
   undici-types@5.26.5: {}
 
   uuid@9.0.1: {}
-
-  xml-flow@1.0.4:
-    dependencies:
-      sax: 1.6.0
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
Update the NaPTAN Uploader to use data in Landing Zone s3. Updating to support loading in the full NaPTAN XML file, taking into account node-level limit on string sizes (512MB), Naptan file is over 530MB. 
I am streaming the file using xml-flow to avoid parsing the entire file.