### PR TITLE
fix: deduplicate atco code primary key

### DIFF
--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -316,11 +316,15 @@ const insertNaptanData = async (dbClient: KyselyDb, naptanStops: unknown[], napt
         },
     );
 
-    const numStopRows = naptanStops.length;
+    const dedupedStops = Array.from(
+        new Map((naptanStops as NaptanStop[]).map((stop) => [stop.atco_code, stop])).values(),
+    )
+
+    const numStopRows = dedupedStops.length;
     const stopBatches = [];
 
-    while (naptanStops.length > 0) {
-        const chunk = naptanStops.splice(0, 1000);
+    while (dedupedStops.length > 0) {
+        const chunk = dedupedStops.splice(0, 1000);
         stopBatches.push(chunk);
     }
 
@@ -332,6 +336,7 @@ const insertNaptanData = async (dbClient: KyselyDb, naptanStops: unknown[], napt
             return dbClient
                 .insertInto("naptan_stop_new")
                 .values(batch as NaptanStop[])
+                .onConflict((oc) => oc.column("atco_code").doNothing())
                 .execute()
                 .then(() => 0);
         },

--- a/src/functions/naptan-uploader/index.ts
+++ b/src/functions/naptan-uploader/index.ts
@@ -318,7 +318,7 @@ const insertNaptanData = async (dbClient: KyselyDb, naptanStops: unknown[], napt
 
     const dedupedStops = Array.from(
         new Map((naptanStops as NaptanStop[]).map((stop) => [stop.atco_code, stop])).values(),
-    )
+    );
 
     const numStopRows = dedupedStops.length;
     const stopBatches = [];


### PR DESCRIPTION
Error coming up in the lambda when inserting naptan data into the database where there are duplicate atco codes.

I added a deduplication step, to dedup on atco codes before chunking.
I've also added .onConflict((oc) => oc.column("atco_code").doNothing()) to napta_stops_new, to align with the conflict handling seen in the naptan_stops_area_new.