### PR TITLE
feat: Add integrated_data_rw Secrets Manager secret

### DIFF
--- a/terraform/modules/database/aurora-db/main.tf
+++ b/terraform/modules/database/aurora-db/main.tf
@@ -287,3 +287,8 @@ resource "aws_secretsmanager_secret" "integrated_data_db_user_ro" {
   name        = "rds/user/integrated_data_read_only"
   description = "Secret for the integrated data database read-only user"
 }
+
+resource "aws_secretsmanager_secret" "integrated_data_db_user_rw" {
+  name        = "rds/user/integrated_data_rw"
+  description = "Secret for the integrated data database read-write user"
+}


### PR DESCRIPTION
**Summary**

Add empty Secrets Manager secret for `integrated_data_rw` role.

**Details**
- Creates `aws_secretsmanager_secret` for integrated_data_rw (name: rds/user/integrated_data_rw)
- Follows existing pattern from integrated_data_read_only secret
- Empty secret - password to be manually added after database role is created
- Aligns with ticket requirement to provide RW credentials for data team analysis

**Changes**
- terraform/modules/database/aurora-db/main.tf: Add integrated_data_rw secret resource

**Testing**
- Terraform validate passes
- Pattern matches existing read-only secret
- Ready for terraform apply to create empty secret in AWS