### PR TITLE
DBODS-2532 - Readme files for loading and integration testing

### DIFF
--- a/integration-testing/README.md
+++ b/integration-testing/README.md
@@ -1,0 +1,97 @@
+# Integration Testing
+
+## Overview
+
+Integration tests for the BODS Integrated Data platform. Tests are written using [Playwright](https://playwright.dev/) and exercise live AWS-backed APIs in the `dev` or `test` environments.
+
+The tests require valid AWS credentials configured for the `eu-west-2` region, as they interact directly with AWS services (DynamoDB, Secrets Manager, SQS, Lambda, EventBridge Scheduler, and CloudWatch) to set up and tear down test state.
+
+## Prerequisites
+
+- [pnpm](https://pnpm.io/) installed
+- AWS credentials configured for `eu-west-2` with permissions to read Secrets Manager, and read/write DynamoDB, SQS, Lambda, EventBridge Scheduler, and CloudWatch
+
+## Setup
+
+Install dependencies from the workspace root:
+
+```bash
+pnpm install
+```
+
+## Running tests
+
+Tests must target either the `dev` or `test` environment via the `STAGE` environment variable.
+
+Run against the **dev** environment:
+
+```bash
+pnpm test:dev
+```
+
+Run against the **test** environment:
+
+```bash
+pnpm test:test
+```
+
+Run against a custom stage:
+
+```bash
+STAGE=<stage> pnpm test
+```
+
+> **Note:** Tests can only be run against `dev` or `test` environments. They will throw an error if run against any other stage.
+
+## Type checking
+
+```bash
+pnpm check-types
+```
+
+## Test suites
+
+### AVL Producer API (`tests/avl-producer-api.spec.ts`)
+
+Tests the AVL Producer API at `https://avl-producer.<stage>.integrated-data.dft-create-data.com`.
+
+The API key is fetched from AWS Secrets Manager before the suite runs. A test subscription is created fresh for each run and cleaned up afterwards.
+
+| Test | Description |
+|------|-------------|
+| Creates a subscription | `POST /subscriptions` — expects `201` and the subscription to appear as `live` |
+| Updates a subscription | `PUT /subscriptions/:id` — expects `204` and the subscription to remain `live` |
+| Posts AVL data to the data endpoint | `POST /subscriptions/:id?apiKey=…` — sends a SIRI heartbeat and SIRI-VM payload, expects `200` and timestamps to be recorded on the subscription |
+| Unsubscribes a subscription | `DELETE /subscriptions/:id` — expects `204` and the subscription status to change to `inactive` |
+
+### AVL Consumer API (`tests/avl-consumer-api.spec.ts`)
+
+Tests the AVL Consumer API (environment-specific URL resolved from `STAGE`).
+
+A test producer subscription is seeded into DynamoDB before the suite runs. Any pre-existing consumer subscription is cleaned up beforehand, and both are removed afterwards.
+
+| Test | Description |
+|------|-------------|
+| Returns SIRI-VM data (no query params) | `GET /siri-vm` — expects `200` |
+| Returns SIRI-VM data (with query params) | `GET /siri-vm?<filters>` — expects `200` with filters for subscriptionId, name, operatorRef, lineRef, vehicleRef, producerRef, originRef, destinationRef, and boundingBox |
+| Creates a consumer subscription | `POST /siri-vm/subscriptions` — sends a SIRI `SubscriptionRequest` XML body, expects `200` |
+| Rejects an immediate unsubscribe | `DELETE /siri-vm/subscriptions` — expects `503` when called too soon after subscribing (the SQS event source mapping has not yet been created) |
+| Unsubscribes a consumer subscription | `DELETE /siri-vm/subscriptions` — waits 15 seconds for the event source mapping to be ready, then expects `204` |
+
+## Project structure
+
+```
+integration-testing/
+├── data/
+│   ├── mockHeartbeat.ts      # Generates SIRI XML HeartbeatNotification payloads
+│   └── mockSiri.ts           # Generates SIRI-VM XML VehicleMonitoring payloads
+├── tests/
+│   ├── avl-consumer-api.spec.ts
+│   └── avl-producer-api.spec.ts
+├── utils/
+│   ├── awsClients.ts         # AWS SDK client factories (eu-west-2)
+│   └── index.ts              # DynamoDB, Secrets Manager, SQS, Lambda, Scheduler, CloudWatch helpers
+├── playwright.config.ts
+├── tsconfig.json
+└── package.json
+```

--- a/load-testing/README.md
+++ b/load-testing/README.md
@@ -23,13 +23,13 @@ k6 login cloud --token <your-grafana-cloud-token>
 Pass the filename and any required environment variables using the `-e` flag:
 
 ```bash
-k6 run -e <VAR>=<value> <script>.js
+k6 run -e <EnvURL> <script>.js
 ```
 
 ### On Grafana Cloud
 
 ```bash
-k6 cloud -e <VAR>=<value> <script>.js
+k6 cloud -e <EnvURL> <script>.js
 ```
 
 ---

--- a/load-testing/README.md
+++ b/load-testing/README.md
@@ -132,6 +132,36 @@ Same ramp profile as `siri-vm-downloader.js` (0 → 30 → 50 → 0 VUs). Scenar
 
 ---
 
+## Clearing the AVL consumer queues
+
+After a load test run you may need to purge the consumer subscriptions, SQS queues, and CloudWatch alarms that were created. The `avl_consumer_cleardown.sh` script does this automatically.
+
+Log in to the AWS profile first:
+
+```bash
+aws sso login --profile bods-non-prod
+```
+
+If that doesn't pick up, export the profile explicitly:
+
+```bash
+export AWS_PROFILE="bods-non-prod"
+```
+
+Make the script executable (first run only):
+
+```bash
+chmod +x avl_consumer_cleardown.sh
+```
+
+Then run it from the `load-testing/` directory:
+
+```bash
+./avl_consumer_cleardown.sh
+```
+
+---
+
 ## Project structure
 
 ```
@@ -139,5 +169,6 @@ load-testing/
 ├── avl-consumer-subscriptions.js   # Subscribe/unsubscribe load test for AVL Consumer API
 ├── siri-vm-downloader.js           # SIRI-VM endpoint load test (ramping VUs, multiple query patterns)
 ├── gtfs-rt-downloader.js           # GTFS-RT endpoint load test (ramping VUs, multiple query patterns)
+├── avl_consumer_cleardown.sh       # Clears consumer subscriptions, SQS queues and CloudWatch alarms
 └── README.md
 ```

--- a/load-testing/README.md
+++ b/load-testing/README.md
@@ -38,18 +38,19 @@ k6 cloud -e <VAR>=<value> <script>.js
 
 ### `avl-consumer-subscriptions.js`
 
-Load tests the AVL Consumer API subscription and unsubscription endpoints (hardcoded to the `test` environment API Gateway).
+Load tests the AVL Consumer API subscription and unsubscription endpoints.
 
 **Required environment variables**
 
 | Variable | Description |
 |----------|-------------|
+| `BASE_URL` | Base URL of the AVL Consumer API (e.g. `https://<api-id>.execute-api.eu-west-2.amazonaws.com/v1`) |
 | `API_KEY` | API key sent as the `x-api-key` request header |
 
 **Example**
 
 ```bash
-k6 run -e API_KEY=load-5 avl-consumer-subscriptions.js
+k6 run -e BASE_URL=https://6tfu67dcng.execute-api.eu-west-2.amazonaws.com/v1 -e API_KEY=load-5 avl-consumer-subscriptions.js
 ```
 
 **Scenarios**

--- a/load-testing/README.md
+++ b/load-testing/README.md
@@ -1,15 +1,142 @@
-# Load testing
+# Load Testing
 
 ## Overview
 
-Load testing is performed using [k6](https://k6.io/). First install k6: <https://grafana.com/docs/k6/latest/set-up/install-k6/>.
+Load testing is performed using [k6](https://k6.io/). All test scripts are configured to run from the `amazon:gb:london` load zone, making them suitable for execution via [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/).
 
 To learn more about using k6, visit the k6 docs: <https://grafana.com/docs/k6/latest/get-started/running-k6/>.
 
+## Prerequisites
+
+Install k6: <https://grafana.com/docs/k6/latest/set-up/install-k6/>
+
+For cloud runs, authenticate with Grafana Cloud:
+
+```bash
+k6 login cloud --token <your-grafana-cloud-token>
+```
+
 ## Running tests
 
-Pass the filename and any environment variables using the `-e` flag, for example:
+### Locally
+
+Pass the filename and any required environment variables using the `-e` flag:
+
+```bash
+k6 run -e <VAR>=<value> <script>.js
+```
+
+### On Grafana Cloud
+
+```bash
+k6 cloud -e <VAR>=<value> <script>.js
+```
+
+---
+
+## Test scripts
+
+### `avl-consumer-subscriptions.js`
+
+Load tests the AVL Consumer API subscription and unsubscription endpoints (hardcoded to the `test` environment API Gateway).
+
+**Required environment variables**
+
+| Variable | Description |
+|----------|-------------|
+| `API_KEY` | API key sent as the `x-api-key` request header |
+
+**Example**
 
 ```bash
 k6 run -e API_KEY=load-5 avl-consumer-subscriptions.js
+```
+
+**Scenarios**
+
+| Scenario | Executor | VUs | Iterations per VU | Start time | What it does |
+|----------|----------|-----|-------------------|------------|--------------|
+| `subscribe_scenario` | `per-vu-iterations` | 3 | 1 000 | 0s | `POST /siri-vm/subscriptions` — creates 3 000 consumer subscriptions. The first 25% target a large-data producer, the remainder a small-data producer |
+| `unsubscribe_scenario` | `per-vu-iterations` | 3 | 1 000 | 15m | `DELETE /siri-vm/subscriptions` — unsubscribes all 3 000 subscriptions created in the subscribe phase |
+
+> **Note:** The 15-minute gap between subscribe and unsubscribe gives the SQS event source mappings time to be created before teardown.
+
+**Subscription IDs used**
+
+- Small-data producer: `14964`
+- Large-data producer: `3492` (used for the first 25% of iterations)
+
+---
+
+### `siri-vm-downloader.js`
+
+Load tests the SIRI-VM data endpoint across a range of query patterns using ramping virtual users.
+
+**Required environment variables**
+
+| Variable | Description |
+|----------|-------------|
+| `BASE_URL` | Base URL of the AVL Consumer API (e.g. `https://<api-id>.execute-api.eu-west-2.amazonaws.com/v1`) |
+
+**Example**
+
+```bash
+k6 run -e BASE_URL=https://6tfu67dcng.execute-api.eu-west-2.amazonaws.com/v1 siri-vm-downloader.js
+```
+
+**Scenarios**
+
+Each scenario ramps from 0 → 30 VUs over 1 minute, holds at 50 VUs for 3.5 minutes, then ramps back to 0 over 30 seconds. Scenarios run sequentially, offset by 5-minute intervals.
+
+| Scenario | Start time | Endpoint called |
+|----------|------------|-----------------|
+| `worst_case_scenario` | 0m | `GET /siri-vm?boundingBox=-13.43…,48.67…,4.27…,59.53…` (whole GB bounding box) |
+| `no_query_params_scenario` | 5m | `GET /siri-vm` |
+| `small_bounding_box_scenario` | 10m | `GET /siri-vm?boundingBox=-1.67…,53.74…,-1.41…,53.88…` (Leeds area) |
+| `large_bounding_box_scenario` | 15m | `GET /siri-vm?boundingBox=-2.86…,52.27…,-0.49…,54.74…` (Yorkshire/Midlands) |
+| `operator_ref_scenario` | 20m | `GET /siri-vm?operatorRef=WDBC` |
+
+**Total duration:** ~25 minutes
+
+---
+
+### `gtfs-rt-downloader.js`
+
+Load tests the GTFS-RT data endpoint across the same bounding-box patterns used by `siri-vm-downloader.js`.
+
+**Required environment variables**
+
+| Variable | Description |
+|----------|-------------|
+| `BASE_URL` | Base URL of the GTFS-RT Consumer API (e.g. `https://<api-id>.execute-api.eu-west-2.amazonaws.com/v1`) |
+
+**Example**
+
+```bash
+k6 run -e BASE_URL=https://<api-id>.execute-api.eu-west-2.amazonaws.com/v1 gtfs-rt-downloader.js
+```
+
+**Scenarios**
+
+Same ramp profile as `siri-vm-downloader.js` (0 → 30 → 50 → 0 VUs). Scenarios run sequentially offset by 5 minutes.
+
+| Scenario | Start time | Endpoint called |
+|----------|------------|-----------------|
+| `worst_case_scenario` | 0m | `GET /gtfs-rt?startTimeAfter=1` |
+| `no_query_params_scenario` | 5m | `GET /gtfs-rt` |
+| `small_bounding_box_scenario` | 10m | `GET /gtfs-rt?boundingBox=-1.67…,53.74…,-1.41…,53.88…` (Leeds area) |
+| `large_bounding_box_scenario` | 15m | `GET /gtfs-rt?boundingBox=-2.86…,52.27…,-0.49…,54.74…` (Yorkshire/Midlands) |
+
+**Total duration:** ~20 minutes
+
+---
+
+## Project structure
+
+```
+load-testing/
+├── avl-consumer-subscriptions.js   # Subscribe/unsubscribe load test for AVL Consumer API
+├── siri-vm-downloader.js           # SIRI-VM endpoint load test (ramping VUs, multiple query patterns)
+├── gtfs-rt-downloader.js           # GTFS-RT endpoint load test (ramping VUs, multiple query patterns)
+└── README.md
 ```

--- a/load-testing/avl-consumer-subscriptions.js
+++ b/load-testing/avl-consumer-subscriptions.js
@@ -51,7 +51,7 @@ export function subscribe_scenario() {
             ? LARGE_PRODUCER_SUBSCRIPTION_ID
             : SMALL_PRODUCER_SUBSCRIPTION_ID;
 
-    const url = `https://6tfu67dcng.execute-api.eu-west-2.amazonaws.com/v1/siri-vm/subscriptions?subscriptionId=${producerSubscriptionId}`;
+    const url = `${__ENV.BASE_URL}/siri-vm/subscriptions?subscriptionId=${producerSubscriptionId}`;
 
     const body = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Siri version="2.0" xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri http://www.siri.org.uk/schema/2.0/xsd/siri.xsd">
@@ -83,7 +83,7 @@ export function subscribe_scenario() {
 export function unsubscribe_scenario() {
     const subscriptionId = `load-${exec.scenario.iterationInTest}`;
 
-    const url = "https://6tfu67dcng.execute-api.eu-west-2.amazonaws.com/v1/siri-vm/subscriptions";
+    const url = `${__ENV.BASE_URL}/siri-vm/subscriptions`;
 
     const body = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Siri version="2.0" xmlns="http://www.siri.org.uk/siri"

--- a/load-testing/avl_consumer_cleardown.sh
+++ b/load-testing/avl_consumer_cleardown.sh
@@ -1,0 +1,5 @@
+aws scheduler list-schedules --region eu-west-2 --query 'Schedules [?contains(Name, `consumer-sub`)].[Name,GroupName]' --output text | xargs -P 8 -n2 sh -c 'aws scheduler delete-schedule --region eu-west-2 --name "$1" --group-name "$2" && echo "deleted $1"' _
+
+aws sqs list-queues --region eu-west-2 --page-size 1000 --query 'QueueUrls[?contains(@, `consumer-sub`)]' --output text | tr '\t' '\n' | xargs -P 8 -n1 -I{} sh -c 'aws sqs delete-queue --region eu-west-2 --queue-url "$1" && echo "deleted $1"' _ {}
+
+aws cloudwatch describe-alarms --region eu-west-2 --query 'MetricAlarms[?contains(AlarmName, `consumer-queue-alarm`)].AlarmName' --output text | tr '\t' '\n' | xargs -n100 aws cloudwatch delete-alarms --region eu-west-2 --alarm-names


### PR DESCRIPTION
## Summary

Adds a `README.md` to the `integration-testing/` folder documenting the integration test suite for the BODS Integrated Data platform.

## Changes

- `integration-testing/README.md` — new file covering:
  - Overview of the test suite (Playwright, AWS-backed APIs)
  - Prerequisites (pnpm, AWS credentials)
  - Setup and how to run tests against `dev` / `test` environments
  - Type checking
  - Per-suite test tables for AVL Producer API and AVL Consumer API
  - Project structure

## Related

DBODS-2532